### PR TITLE
Final Claude Gmail agent with Remote MCP auth, progressive scoping, and HITL approval

### DIFF
--- a/examples/agents/claude-agent-descope-gmail/.env.example
+++ b/examples/agents/claude-agent-descope-gmail/.env.example
@@ -1,4 +1,6 @@
-ANTHROPIC_API_KEY=your_anthropic_api_key_here
-DESCOPE_PROJECT_ID=your_descope_project_id_here
-DESCOPE_CLIENT_SECRET=your_descope_client_secret_here
-MCP_SERVER_ID=your_mcp_server_id_here
+ANTHROPIC_API_KEY=
+DESCOPE_PROJECT_ID=
+DESCOPE_CLIENT_ID=
+DESCOPE_CLIENT_SECRET=
+MCP_SERVER_ID=
+MCP_SERVER_URL=

--- a/examples/agents/claude-agent-descope-gmail/README.md
+++ b/examples/agents/claude-agent-descope-gmail/README.md
@@ -1,1 +1,113 @@
-# claude-agent-descope-gmail
+# Claude MCP Gmail Agent with Human-in-the-Loop Approval
+
+A secure AI agent that integrates Gmail using Claude's Agents SDK, Model Context Protocol (MCP), and Descope for authentication, authorization, and progressive OAuth scoping with human approval for sensitive actions.
+
+## Features
+
+- 📧 Read emails from Gmail inbox
+- ✉️ Send emails with approval workflow
+- 🔐 Progressive OAuth scoping (permissions requested on-demand)
+- 🎫 Human-in-the-loop approval via Descope Enchanted Links
+- 🔒 Agent never directly handles Gmail tokens (Agent → MCP → Descope → Gmail)
+
+## Prerequisites
+
+- Node.js 18+
+- Descope account and project
+- Anthropic API key
+- Google Cloud project with Gmail API enabled
+
+## Quick Start
+
+### 1. Install Dependencies
+
+```bash
+npm install
+```
+
+### 2. Configure Descope
+
+**Create Inbound App:**
+1. Go to Descope Console → Applications → Inbound Apps
+2. Create new application
+3. Add scopes: `google-read`, `google-send`
+4. Note your Project ID, MCP Server ID, Client ID, and Client Secret
+
+**Create Connection:**
+1. Go to Applications → Connections → Add Connection
+2. Select Gmail
+3. App ID: `gmail`
+4. OAuth Scopes: `gmail.readonly`, `gmail.send`
+5. Redirect URL: `http://localhost:3000/connection-complete`
+
+**Enable Enchanted Link:**
+1. Go to Authentication Methods → Enchanted Link
+2. Enable and configure
+
+### 3. Set Environment Variables
+
+Create a `.env` file:
+
+```env
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+DESCOPE_PROJECT_ID=your_descope_project_id_here
+DESCOPE_CLIENT_ID=your_descope_client_id_here
+DESCOPE_CLIENT_SECRET=your_descope_client_secret_here
+MCP_SERVER_ID=your_mcp_server_id_here
+```
+
+### 4. Run the Agent
+
+```bash
+npm start
+```
+
+## Usage
+
+**Read emails:**
+```
+You: Read my latest emails
+```
+
+**Send email:**
+```
+You: Send an email to test@example.com with subject "Hello" and body "Test message"
+```
+
+The agent will request Gmail permissions only when needed and require approval before sending any email.
+
+## Architecture
+
+```
+User → Agent (Claude) → MCP Server → Descope → Gmail API
+```
+
+The agent never directly handles Gmail OAuth tokens. The MCP server requests them from Descope, creating an extra security boundary.
+
+## Security
+
+- **Authentication**: OAuth 2.0 via Descope Inbound Apps
+- **Authorization**: Tool-level scopes
+- **Progressive Scoping**: Gmail permissions requested on-demand
+- **Human Approval**: Enchanted Links for sensitive actions
+- **Token Isolation**: Agent never touches Gmail tokens
+
+## Project Structure
+
+```
+src/
+├── cli-agent.ts       # Main agent
+├── mcp-stdio.ts       # MCP server with Gmail tools
+├── auth.ts            # Descope authentication
+└── approval.ts        # Enchanted Link approval
+```
+
+## Learn More
+
+- [Claude Agents SDK](https://github.com/anthropics/anthropic-sdk-typescript)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Descope Documentation](https://docs.descope.com/)
+
+## License
+
+MIT

--- a/examples/agents/claude-agent-descope-gmail/README.md
+++ b/examples/agents/claude-agent-descope-gmail/README.md
@@ -1,113 +1,117 @@
-# Claude MCP Gmail Agent with Human-in-the-Loop Approval
+# Claude Gmail Agent with Descope
 
-A secure AI agent that integrates Gmail using Claude's Agents SDK, Model Context Protocol (MCP), and Descope for authentication, authorization, and progressive OAuth scoping with human approval for sensitive actions.
+A Claude-powered AI agent that integrates with Gmail through the Model Context Protocol (MCP), using Descope's Agentic Identity Hub for authentication, progressive OAuth scoping, and human-in-the-loop email approval.
 
-## Features
+Read the full tutorial: [Build a Claude Gmail Agent with Descope](#) <!-- add blog link once published -->
 
-- 📧 Read emails from Gmail inbox
-- ✉️ Send emails with approval workflow
-- 🔐 Progressive OAuth scoping (permissions requested on-demand)
-- 🎫 Human-in-the-loop approval via Descope Enchanted Links
-- 🔒 Agent never directly handles Gmail tokens (Agent → MCP → Descope → Gmail)
+## What This Does
+
+- Authenticates users via Descope's OAuth 2.0 consent flow
+- Connects to a remote MCP server deployed on Vercel
+- Reads Gmail inbox using progressive OAuth scoping (`gmail.readonly`)
+- Sends emails with human-in-the-loop approval via Descope Enchanted Link (`gmail.send`)
+- Verifies MCP access token and enforces required scopes at connection time
+
+## Architecture
+
+```
+CLI Agent → Descope (auth) → Remote MCP Server (Vercel) → Gmail API
+```
+
+The MCP server handles all on-behalf-of token management. The agent never directly touches Gmail OAuth credentials — it calls tools, the MCP server fetches the right token from Descope, makes the API call, and returns the result.
+
+The MCP server is based on Descope's [Next.js MCP template](https://github.com/descope/mcp-with-next-js-and-descope). Deploy your own instance and point the agent at it.
 
 ## Prerequisites
 
 - Node.js 18+
-- Descope account and project
-- Anthropic API key
-- Google Cloud project with Gmail API enabled
+- [Anthropic API key](https://console.anthropic.com)
+- [Descope account](https://www.descope.com) with:
+  - A Gmail Connection configured in Agentic Identity Hub
+  - An MCP Server configured with `google-read` and `google-send` scopes
+- Google Cloud Console project with OAuth credentials (client ID and secret)
+- A deployed instance of the [Descope Next.js MCP template](https://github.com/descope/mcp-with-next-js-and-descope)
 
-## Quick Start
+## Setup
 
-### 1. Install Dependencies
+**1. Install dependencies**
 
 ```bash
 npm install
 ```
 
-### 2. Configure Descope
+**2. Configure environment variables**
 
-**Create Inbound App:**
-1. Go to Descope Console → Applications → Inbound Apps
-2. Create new application
-3. Add scopes: `google-read`, `google-send`
-4. Note your Project ID, MCP Server ID, Client ID, and Client Secret
-
-**Create Connection:**
-1. Go to Applications → Connections → Add Connection
-2. Select Gmail
-3. App ID: `gmail`
-4. OAuth Scopes: `gmail.readonly`, `gmail.send`
-5. Redirect URL: `http://localhost:3000/connection-complete`
-
-**Enable Enchanted Link:**
-1. Go to Authentication Methods → Enchanted Link
-2. Enable and configure
-
-### 3. Set Environment Variables
-
-Create a `.env` file:
-
-```env
-ANTHROPIC_API_KEY=your_anthropic_api_key_here
-DESCOPE_PROJECT_ID=your_descope_project_id_here
-DESCOPE_CLIENT_ID=your_descope_client_id_here
-DESCOPE_CLIENT_SECRET=your_descope_client_secret_here
-MCP_SERVER_ID=your_mcp_server_id_here
-```
-
-### 4. Run the Agent
+Copy the example env file and fill in your values:
 
 ```bash
-npm start
+cp .env.example .env
 ```
 
-## Usage
+```env
+ANTHROPIC_API_KEY=your_anthropic_api_key
 
-**Read emails:**
-```
-You: Read my latest emails
-```
+DESCOPE_PROJECT_ID=your_descope_project_id
+DESCOPE_CLIENT_ID=your_mcp_server_client_id
+DESCOPE_CLIENT_SECRET=your_mcp_server_client_secret
+MCP_SERVER_ID=your_mcp_server_id
 
-**Send email:**
-```
-You: Send an email to test@example.com with subject "Hello" and body "Test message"
-```
-
-The agent will request Gmail permissions only when needed and require approval before sending any email.
-
-## Architecture
-
-```
-User → Agent (Claude) → MCP Server → Descope → Gmail API
+MCP_SERVER_URL=https://your-vercel-app.vercel.app/api/mcp
 ```
 
-The agent never directly handles Gmail OAuth tokens. The MCP server requests them from Descope, creating an extra security boundary.
+You can find `DESCOPE_PROJECT_ID`, `DESCOPE_CLIENT_ID`, `DESCOPE_CLIENT_SECRET`, and `MCP_SERVER_ID` in your Descope Console under **Agentic Identity Hub → MCP Servers → your server → Usage Samples**.
 
-## Security
+**3. Run the agent**
 
-- **Authentication**: OAuth 2.0 via Descope Inbound Apps
-- **Authorization**: Tool-level scopes
-- **Progressive Scoping**: Gmail permissions requested on-demand
-- **Human Approval**: Enchanted Links for sensitive actions
-- **Token Isolation**: Agent never touches Gmail tokens
+```bash
+npx tsx src/cli-agent.ts
+```
+
+## How It Works
+
+**Authentication**
+
+On startup, the agent opens a browser for you to authenticate with Descope. After you authorize the `google-read` and `google-send` MCP scopes, you're redirected back and the agent receives an MCP access token.
+
+**Connection-time scope verification**
+
+When the agent connects to the remote MCP server, the server validates the token and checks for the `google-read` scope before allowing any tools to be called. Connections without the required scope are rejected immediately.
+
+**Reading emails**
+
+Type `read emails` in the chat. If you haven't connected Gmail yet, the agent opens a browser for you to grant `gmail.readonly` access. Once granted, the MCP server fetches your Gmail token from Descope on your behalf and returns your latest emails.
+
+**Sending emails**
+
+Type `send email to <address>` in the chat. The agent first checks for `gmail.send` permission (requesting it if needed), then triggers a human approval step. You'll receive an Enchanted Link in your email — click it to approve, and the email sends.
+
+**Exiting**
+
+Type `exit` to quit.
 
 ## Project Structure
 
 ```
 src/
-├── cli-agent.ts       # Main agent
-├── mcp-stdio.ts       # MCP server with Gmail tools
-├── auth.ts            # Descope authentication
-└── approval.ts        # Enchanted Link approval
+  cli-agent.ts   # Main agent: OAuth callbacks, MCP connection, chat loop
+  auth.ts        # Descope authentication helper
+  approval.ts    # Enchanted Link approval polling
 ```
 
-## Learn More
+## Environment Variables Reference
 
-- [Claude Agents SDK](https://github.com/anthropics/anthropic-sdk-typescript)
-- [Model Context Protocol](https://modelcontextprotocol.io/)
-- [Descope Documentation](https://docs.descope.com/)
+| Variable | Description |
+|---|---|
+| `ANTHROPIC_API_KEY` | Your Anthropic API key |
+| `DESCOPE_PROJECT_ID` | Your Descope project ID |
+| `DESCOPE_CLIENT_ID` | MCP server OAuth client ID |
+| `DESCOPE_CLIENT_SECRET` | MCP server OAuth client secret |
+| `MCP_SERVER_ID` | Your Descope MCP server ID |
+| `MCP_SERVER_URL` | URL of your deployed MCP server |
 
-## License
+## Related
 
-MIT
+- [Descope Agentic Identity Hub docs](https://docs.descope.com/agentic-identity-hub)
+- [MCP specification](https://spec.modelcontextprotocol.io)
+- [Descope Next.js MCP template](https://github.com/descope/mcp-with-next-js-and-descope)
+- [Anthropic Claude SDK](https://github.com/anthropic-ai/sdk-python)

--- a/examples/agents/claude-agent-descope-gmail/package.json
+++ b/examples/agents/claude-agent-descope-gmail/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "mcp": "ts-node src/mcp-http-server.ts",
     "start": "tsx src/cli-agent.ts"
   },
   "repository": {

--- a/examples/agents/claude-agent-descope-gmail/package.json
+++ b/examples/agents/claude-agent-descope-gmail/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "mcp": "ts-node src/mcp-stdio.ts",
+    "mcp": "ts-node src/mcp-http-server.ts",
     "start": "tsx src/cli-agent.ts"
   },
   "repository": {
@@ -15,7 +15,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "module",
+  "type": "commonjs",
   "bugs": {
     "url": "https://github.com/kashvipahuja-dev/claude-agent-descope-gmail/issues"
   },
@@ -24,7 +24,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.7",
     "@anthropic-ai/sdk": "^0.71.2",
     "@descope/node-sdk": "^1.9.1",
-    "@modelcontextprotocol/sdk": "^1.25.3",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "dotenv": "^17.2.3",
     "express": "^5.2.1"
   },

--- a/examples/agents/claude-agent-descope-gmail/src/auth.ts
+++ b/examples/agents/claude-agent-descope-gmail/src/auth.ts
@@ -6,11 +6,12 @@ const MCP_SERVER_ID = process.env.MCP_SERVER_ID!;
 const DESCOPE_CLIENT_ID = process.env.DESCOPE_CLIENT_ID!;
 
 export function authenticateUser() {
-  const authUrl = `https://api.descope.com/oauth2/v1/apps/agentic/${DESCOPE_PROJECT_ID}/${MCP_SERVER_ID}/authorize?response_type=code&client_id=${DESCOPE_CLIENT_ID}&redirect_uri=http://localhost:3000/callback&scope=google-read+google-send&flow=inbound-apps-user-consent`;
-  
+  const scopes = encodeURIComponent("google-read google-send outbound.token.fetch");
+  const authUrl = `https://api.descope.com/oauth2/v1/apps/agentic/${DESCOPE_PROJECT_ID}/${MCP_SERVER_ID}/authorize?response_type=code&client_id=${DESCOPE_CLIENT_ID}&redirect_uri=http://localhost:3000/callback&scope=${scopes}&flow=inbound-apps-user-consent`;
+
   console.log("\nOpening browser for authentication...");
   console.log(`\nIf browser doesn't open, visit:\n${authUrl}\n`);
-  
+
   exec(`open "${authUrl}"`, (error) => {
     if (error) {
       console.log("Could not open browser automatically");

--- a/examples/agents/claude-agent-descope-gmail/src/cli-agent.ts
+++ b/examples/agents/claude-agent-descope-gmail/src/cli-agent.ts
@@ -175,7 +175,7 @@ async function main() {
       }
 
       const payload = JSON.parse(
-        Buffer.from(tokenData.access_token.split(".")[1], "base64").toString()
+        Buffer.from(tokenData.access_token.split(".")[1], "base64url").toString()
       );
       const uid = payload.sub ?? "";
 
@@ -234,7 +234,7 @@ async function main() {
   console.log("\nStep 2: Connecting to remote MCP server...");
 
   const transport = new StreamableHTTPClientTransport(
-    new URL("https://mcp-with-next-js-and-descope-beryl.vercel.app/api/mcp"),
+    new URL(process.env.MCP_SERVER_URL!),
     {
       requestInit: {
         headers: { Authorization: `Bearer ${userToken}` },
@@ -336,7 +336,7 @@ async function runAgent(userMessage: string, mcpClient: Client): Promise<string>
         CallToolResultSchema
       );
 
-      const resultContent = toolResult.content[0].text;
+      const resultContent = toolResult.content?.[0]?.text ?? "";
 
       // ── Approval flow (send email) ─────────────────────────────────────
       if (resultContent.startsWith("NEEDS_APPROVAL:")) {
@@ -392,16 +392,35 @@ async function runAgent(userMessage: string, mcpClient: Client): Promise<string>
           console.log("Please grant permission in your browser.");
           console.log("⏳ Waiting for you to complete the OAuth flow...\n");
 
-          // Give the user time to complete OAuth in browser
-          await new Promise((r) => setTimeout(r, 15_000));
-          console.log("Retrying...\n");
+          let tokenAvailable = false;
+          let attempts = 0;
+          while (attempts < 20 && !tokenAvailable) {
+            await new Promise(r => setTimeout(r, 3000));
+            attempts++;
+            const check = await fetch(
+              "https://api.descope.com/v1/mgmt/outbound/app/user/token/latest",
+              {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${DESCOPE_PROJECT_ID}:${userToken}`,
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ appId: "gmail", loginId: userId }),
+              }
+            );
+            if (check.ok) {
+              console.log("✅ Permission granted! Retrying...\n");
+              tokenAvailable = true;
+            }
+          }
 
           messages.push({
             role: "user",
             content: [{
               type: "tool_result",
               tool_use_id: toolUse.id,
-              content: "Permission granted. Please retry.",
+              content: tokenAvailable ? "Permission granted. Please retry." : "Timeout waiting for permission.",
+              ...(tokenAvailable ? {} : { is_error: true }),
             }],
           });
           continue;

--- a/examples/agents/claude-agent-descope-gmail/src/cli-agent.ts
+++ b/examples/agents/claude-agent-descope-gmail/src/cli-agent.ts
@@ -1,12 +1,11 @@
 import Anthropic from "@anthropic-ai/sdk";
+import "dotenv/config";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import * as readline from "readline";
 import { authenticateUser, fetchUserEmail } from "./auth.js";
 import express from "express";
-import {
-  CallToolResultSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
 const DESCOPE_PROJECT_ID = process.env.DESCOPE_PROJECT_ID!;
@@ -26,48 +25,42 @@ const pendingEmails = new Map<string, PendingEmail>();
 let userToken: string;
 let userId: string;
 let userEmail: string;
+let refreshToken: string;
 
 async function main() {
   console.log("\nGmail AI Agent");
   console.log("=".repeat(50));
 
   const app = express();
-  
+
+  // ── Gmail OAuth connection-complete callback ───────────────────────────────
+  // Called after user grants Gmail access via the authorization_url
   app.get("/connection-complete", (req: any, res: any) => {
     const error = req.query.err as string;
 
     if (error) {
-      console.error("\n❌ OAuth ERROR from Descope:");
-      console.error(`Error code: ${error}`);
-      console.error(`Full URL: ${req.url}`);
-
+      console.error("\n❌ Gmail OAuth error:", decodeURIComponent(error));
       res.send(`
-        <html>
-          <body style="font-family: Arial; padding: 40px; text-align: center;">
-            <h1 style="color: red;">OAuth Error</h1>
-            <p>Error: ${decodeURIComponent(error)}</p>
-            <p>Please check the terminal for details.</p>
-          </body>
-        </html>
-      `);
+        <html><body style="font-family:Arial;padding:40px;text-align:center">
+          <h1 style="color:red">OAuth Error</h1>
+          <p>${decodeURIComponent(error)}</p>
+        </body></html>`);
       return;
     }
 
-    console.error("\n✅ OAuth completed successfully");
+    console.log("\n✅ Gmail connected — token stored in Descope!");
     res.send(`
-      <html>
-        <body style="font-family: Arial; padding: 40px; text-align: center;">
-          <h1>Permission Granted!</h1>
-          <p>You can close this window and return to the agent.</p>
-        </body>
-      </html>
-    `);
+      <html><body style="font-family:Arial;padding:40px;text-align:center">
+        <h1>Permission Granted!</h1>
+        <p>You can close this window and return to the terminal.</p>
+      </body></html>`);
   });
 
+  // ── Email approval callback ───────────────────────────────────────────────
   app.get("/approve", async (req: any, res: any) => {
     const token = req.query.t as string;
     const pendingId = req.query.id as string;
-    
+
     if (!token || !pendingId) {
       res.status(400).send("Missing approval token or ID");
       return;
@@ -76,142 +69,78 @@ async function main() {
     const { verifyApproval } = await import("./approval.js");
     const verified = await verifyApproval(token);
 
-    if (verified) {
-      const emailDetails = pendingEmails.get(pendingId);
-      
-      if (!emailDetails) {
-        console.error("Pending email not found:", pendingId);
-        res.status(404).send("Pending email not found");
+    if (!verified) {
+      res.status(400).send("Invalid approval token");
+      return;
+    }
+
+    const emailDetails = pendingEmails.get(pendingId);
+    if (!emailDetails) {
+      res.status(404).send("Pending email not found");
+      return;
+    }
+
+    try {
+      const { to, subject, body } = emailDetails;
+
+      // Fetch Gmail token via mgmt API
+      const tokenResp = await fetch(
+        "https://api.descope.com/v1/mgmt/outbound/app/user/token/latest",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${DESCOPE_PROJECT_ID}:${userToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ appId: "gmail", loginId: userId }),
+        }
+      );
+
+      if (!tokenResp.ok) {
+        const err = await tokenResp.text();
+        res.status(500).send(`Failed to get Gmail token: ${err}`);
         return;
       }
 
-      try {
-        const { to, subject, body, userId: uid, userToken: uToken } = emailDetails;
-        
-        console.log(`Sending email to ${to}...`);
-        const tokenResp = await fetch(
-          "https://api.descope.com/v1/mgmt/outbound/app/user/token/latest",
-          {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${process.env.DESCOPE_PROJECT_ID}:${uToken}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({ appId: "gmail", loginId: uid }),
-          }
-        );
-        
-        if (!tokenResp.ok) {
-          const errorText = await tokenResp.text();
-          console.error("Failed to get Gmail token:", errorText);
-          res.status(500).send(`Failed to get Gmail token: ${errorText}`);
-          return;
+      const tokenData = await tokenResp.json();
+      const gmailToken = tokenData.token?.accessToken ?? tokenData.accessToken;
+
+      const raw = Buffer.from(`To: ${to}\r\nSubject: ${subject}\r\n\r\n${body}`)
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+
+      const sendResp = await fetch(
+        "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${gmailToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ raw }),
         }
-        
-        const tokenData = await tokenResp.json();
-        const gmailToken = tokenData.token.accessToken;
-        
-        const raw = Buffer.from(`To: ${to}\r\nSubject: ${subject}\r\n\r\n${body}`)
-          .toString("base64")
-          .replace(/\+/g, "-")
-          .replace(/\//g, "_")
-          .replace(/=+$/, "");
-        
-        const sendResp = await fetch(
-          "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
-          {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${gmailToken}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({ raw }),
-          }
-        );
-        
-        if (sendResp.ok) {
-          console.log(`Email sent to ${to}!`);
-          pendingEmails.delete(pendingId);
-          res.send(`
-            <html>
-              <body style="font-family: Arial; padding: 40px; text-align: center;">
-                <h1>Email Approved and Sent!</h1>
-                <p>Your email to ${to} has been sent successfully.</p>
-              </body>
-            </html>
-          `);
-        } else {
-          const errorText = await sendResp.text();
-          
-          try {
-            const errorData = JSON.parse(errorText);
-            
-            if (errorData.error?.code === 403 && 
-                errorData.error?.details?.some((d: any) => d.reason === "ACCESS_TOKEN_SCOPE_INSUFFICIENT")) {
-              
-              console.error("Insufficient scopes, requesting additional permission...");
-              
-              const connectResp = await fetch(
-                "https://api.descope.com/v1/mgmt/outbound/app/connect",
-                {
-                  method: "POST",
-                  headers: {
-                    Authorization: `Bearer ${process.env.DESCOPE_PROJECT_ID}:${uToken}`,
-                    "Content-Type": "application/json",
-                  },
-                  body: JSON.stringify({
-                    appId: "gmail",
-                    options: {
-                      redirectUrl: "http://localhost:3000/connection-complete",
-                      scopes: ["https://www.googleapis.com/auth/gmail.send"],
-                    },
-                  }),
-                }
-              );
+      );
 
-              const connectData = await connectResp.json();
-
-              if (!connectData.url) {
-                console.error("No URL in connect response");
-                res.status(500).send(`Failed to get connection URL: ${JSON.stringify(connectData)}`);
-                return;
-              }
-
-              const { exec } = await import("child_process");
-
-              res.send(`
-                <html>
-                  <body style="font-family: Arial; padding: 40px; text-align: center;">
-                    <h1>Additional Permission Required</h1>
-                    <p>Gmail send permission is needed.</p>
-                    <p><a href="${connectData.url}" target="_blank">Click here to grant permission</a></p>
-                    <p>After granting permission, approve the email again.</p>
-                  </body>
-                </html>
-              `);
-
-              exec(`open "${connectData.url}"`);
-              return;
-            }
-          } catch (parseError) {
-            console.error("Could not parse error response");
-          }
-          
-          console.error(`Gmail API error:`, errorText);
-          res.status(500).send(`Failed to send email: ${errorText}`);
-        }
-      } catch (error: any) {
-        console.error(`Exception:`, error);
-        res.status(500).send(`Error: ${error.message}`);
+      if (sendResp.ok) {
+        console.log(`\n✅ Email sent to ${to}!`);
+        pendingEmails.delete(pendingId);
+        res.send(`
+          <html><body style="font-family:Arial;padding:40px;text-align:center">
+            <h1>Email Sent!</h1>
+            <p>Your email to ${to} has been sent successfully.</p>
+          </body></html>`);
+      } else {
+        const err = await sendResp.text();
+        res.status(500).send(`Failed to send email: ${err}`);
       }
-    } else {
-      res.status(400).send("Invalid approval token");
+    } catch (err: any) {
+      res.status(500).send(`Error: ${err.message}`);
     }
   });
 
-  const server = app.listen(3000);
-  console.log("Server started on port 3000\n");
-
+  // ── Descope OAuth callback (step 1 auth) ──────────────────────────────────
   let authResolve: any;
   let authReject: any;
 
@@ -232,46 +161,43 @@ async function main() {
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
           body: new URLSearchParams({
             grant_type: "authorization_code",
-            code: code,
+            code,
             redirect_uri: "http://localhost:3000/callback",
-            client_id: "UDJ0N0NvdjFJTERhYkN1QnJhRmhWbEZzUmwyUDpUUEEzOGZiQXNJVDdrMW5jODRTdkViMnFPaXluNGc=",
+            client_id: process.env.DESCOPE_CLIENT_ID!,
             client_secret: process.env.DESCOPE_CLIENT_SECRET!,
           }),
         }
       );
 
       const tokenData = await tokenResponse.json();
-
       if (!tokenData.access_token) {
         throw new Error(`No access token: ${JSON.stringify(tokenData)}`);
       }
 
-      const tokenParts = tokenData.access_token.split('.');
-      const payload = JSON.parse(Buffer.from(tokenParts[1], 'base64').toString());
-      const userId = payload.sub || "";
+      const payload = JSON.parse(
+        Buffer.from(tokenData.access_token.split(".")[1], "base64").toString()
+      );
+      const uid = payload.sub ?? "";
 
-      // Fetch email from Gmail profile
       let email = "";
       try {
-        email = await fetchUserEmail(userId, tokenData.access_token);
+        email = await fetchUserEmail(uid, tokenData.access_token);
       } catch (e) {
         console.error("Failed to fetch user email:", e);
       }
 
       res.send(`
-        <html>
-          <body style="font-family: Arial; padding: 40px; text-align: center;">
-            <h1>Authentication Successful!</h1>
-            <p>You can close this window and return to the terminal.</p>
-          </body>
-        </html>
-      `);
+        <html><body style="font-family:Arial;padding:40px;text-align:center">
+          <h1>Authentication Successful!</h1>
+          <p>You can close this window and return to the terminal.</p>
+        </body></html>`);
 
       if (authResolve) {
-        authResolve({ 
-          accessToken: tokenData.access_token, 
-          userId,
-          email
+        authResolve({
+          accessToken: tokenData.access_token,
+          refreshToken: tokenData.refresh_token,
+          userId: uid,
+          email,
         });
       }
     } catch (error: any) {
@@ -280,23 +206,41 @@ async function main() {
     }
   });
 
+  app.listen(3000);
+  console.log("Server started on port 3000\n");
+
+  // ── Step 1: Authenticate with Descope ─────────────────────────────────────
   console.log("Step 1: Authenticate with Descope...");
-  const auth = await new Promise<{accessToken: string, userId: string, email: string}>((resolve, reject) => {
+  const auth = await new Promise<{
+    accessToken: string;
+    refreshToken: string;
+    userId: string;
+    email: string;
+  }>((resolve, reject) => {
     authResolve = resolve;
     authReject = reject;
     authenticateUser();
   });
+
   userToken = auth.accessToken;
   userId = auth.userId;
   userEmail = auth.email;
+  refreshToken = auth.refreshToken;
+
   console.log("Authenticated!");
   console.log(`Email: ${userEmail}`);
 
-  console.log("\nStep 2: Starting MCP server...");
-  const transport = new StdioClientTransport({
-    command: "npx",
-    args: ["tsx", "src/mcp-stdio.ts"],
-  });
+  // ── Step 2: Connect to remote MCP server ──────────────────────────────────
+  console.log("\nStep 2: Connecting to remote MCP server...");
+
+  const transport = new StreamableHTTPClientTransport(
+    new URL("https://mcp-with-next-js-and-descope-beryl.vercel.app/api/mcp"),
+    {
+      requestInit: {
+        headers: { Authorization: `Bearer ${userToken}` },
+      },
+    }
+  );
 
   const mcpClient = new Client(
     { name: "cli-agent", version: "1.0.0" },
@@ -304,9 +248,10 @@ async function main() {
   );
 
   await mcpClient.connect(transport);
-  console.log("MCP server connected!");
+  console.log("Connected to remote MCP server!\n");
 
-  console.log("\nChat with your AI agent:");
+  // ── Chat loop ─────────────────────────────────────────────────────────────
+  console.log("Chat with your AI agent:");
   console.log("Commands: 'read emails', 'send email to <address>', 'exit'\n");
 
   const rl = readline.createInterface({
@@ -314,8 +259,8 @@ async function main() {
     output: process.stdout,
   });
 
-  const prompt = (question: string): Promise<string> =>
-    new Promise((resolve) => rl.question(question, resolve));
+  const prompt = (q: string): Promise<string> =>
+    new Promise((resolve) => rl.question(q, resolve));
 
   while (true) {
     const userInput = await prompt("You: ");
@@ -336,21 +281,19 @@ async function main() {
   }
 }
 
+// ─── Agent loop ──────────────────────────────────────────────────────────────
+
 async function runAgent(userMessage: string, mcpClient: Client): Promise<string> {
   const messages: Anthropic.MessageParam[] = [
     { role: "user", content: userMessage },
   ];
 
-  let toolsResponse;
-  try {
-    toolsResponse = await mcpClient.listTools();
-  } catch (error) {
-    console.error("Error getting tools:", error);
-    throw error;
-  }
+  const toolsResponse = await mcpClient.listTools().catch((e) => {
+    console.error("Error getting tools:", e);
+    throw e;
+  });
 
-  const mcpTools = toolsResponse.tools || [];
-
+  const mcpTools = toolsResponse.tools ?? [];
   const anthropicTools: Anthropic.Tool[] = mcpTools.map((tool: any) => ({
     name: tool.name,
     description: tool.description,
@@ -368,154 +311,104 @@ async function runAgent(userMessage: string, mcpClient: Client): Promise<string>
     messages.push({ role: "assistant", content: response.content });
 
     const toolUse = response.content.find(
-      (block): block is Anthropic.ToolUseBlock => block.type === "tool_use"
+      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use"
     );
 
     if (!toolUse) {
-      const textBlock = response.content.find(
-        (block): block is Anthropic.TextBlock => block.type === "text"
+      const text = response.content.find(
+        (b): b is Anthropic.TextBlock => b.type === "text"
       );
-      return textBlock?.text || "Done.";
+      return text?.text ?? "Done.";
     }
 
     console.log(`\nCalling tool: ${toolUse.name}...`);
 
     try {
-      const toolResult: any = await (mcpClient.request as any)({
-        method: "tools/call",
-        params: {
-          name: toolUse.name,
-          arguments: toolUse.input,
-          _meta: { userToken, userId, userEmail },
+      const toolResult: any = await (mcpClient.request as any)(
+        {
+          method: "tools/call",
+          params: {
+            name: toolUse.name,
+            arguments: toolUse.input,
+            _meta: { userToken, refreshToken, userId, userEmail },
+          },
         },
-      }, CallToolResultSchema);
+        CallToolResultSchema
+      );
 
       const resultContent = toolResult.content[0].text;
 
+      // ── Approval flow (send email) ─────────────────────────────────────
       if (resultContent.startsWith("NEEDS_APPROVAL:")) {
         const [header, ...emailParts] = resultContent.split("|||");
         const parts = header.replace("NEEDS_APPROVAL:", "").split(":");
         const pendingRef = parts[0];
         const linkId = parts[1];
         const pendingId = parts[2];
-        const to = emailParts[0];
-        const subject = emailParts[1];
-        const body = emailParts[2];
-        
+
         pendingEmails.set(pendingId, {
-          to,
-          subject,
-          body,
+          to: emailParts[0],
+          subject: emailParts[1],
+          body: emailParts[2],
           userId,
           userToken,
           pendingRef,
         });
+
         console.log(`\nApproval required!`);
         console.log(`Check your email (${userEmail}) for the approval link`);
-        console.log(`Link ID: ${linkId}`);
-        console.log(`Waiting for approval...\n`);
+        console.log(`Link ID: ${linkId}\nWaiting for approval...\n`);
 
         const { waitForApproval } = await import("./approval.js");
         const approved = await waitForApproval(pendingRef);
 
-        if (approved) {
-          messages.push({
-            role: "user",
-            content: [{
-              type: "tool_result",
-              tool_use_id: toolUse.id,
-              content: `Approval received. Please check if the email was sent or if additional permissions are needed.`,
-            }],
-          });
-        } else {
-          messages.push({
-            role: "user",
-            content: [{
-              type: "tool_result",
-              tool_use_id: toolUse.id,
-              content: `Approval timeout or denied.`,
-              is_error: true,
-            }],
-          });
-        }
+        messages.push({
+          role: "user",
+          content: [{
+            type: "tool_result",
+            tool_use_id: toolUse.id,
+            content: approved
+              ? "Approval received. Email sent successfully."
+              : "Approval timeout or denied.",
+            ...(approved ? {} : { is_error: true }),
+          }],
+        });
         continue;
       }
 
-      if (resultContent.startsWith("NEEDS_CONNECTION:")) {
-        const url = resultContent.replace("NEEDS_CONNECTION:", "");
-        console.log(`\n🔐 Gmail permission required. Opening browser...`);
+      // ── Gmail OAuth required (no token yet, or insufficient scope) ─────
+      if (resultContent.includes("insufficient_scope")) {
+        let authUrl = "";
+        try {
+          const errorData = JSON.parse(resultContent);
+          authUrl = errorData.authorization_url ?? "";
+        } catch { /* not JSON */ }
 
-        const { exec } = await import("child_process");
-        exec(`open "${url}"`);
+        if (authUrl) {
+          console.log(`\n🔐 Gmail permission required. Opening browser...`);
+          const { exec } = await import("child_process");
+          exec(`open "${authUrl}"`);
 
-        console.log(`\nPlease grant permission in your browser.`);
-        console.log(`⏳ Waiting for you to click Allow...`);
+          console.log("Please grant permission in your browser.");
+          console.log("⏳ Waiting for you to complete the OAuth flow...\n");
 
-        // Poll for token (max 60 seconds)
-        let tokenAvailable = false;
-        let attempts = 0;
-        const maxAttempts = 20;
+          // Give the user time to complete OAuth in browser
+          await new Promise((r) => setTimeout(r, 15_000));
+          console.log("Retrying...\n");
 
-        while (attempts < maxAttempts && !tokenAvailable) {
-          await new Promise(resolve => setTimeout(resolve, 3000));
-          attempts++;
-          process.stdout.write(".");
-
-          try {
-            const checkResponse = await fetch(
-              "https://api.descope.com/v1/mgmt/outbound/app/user/token/latest",
-              {
-                method: "POST",
-                headers: {
-                  Authorization: `Bearer ${DESCOPE_PROJECT_ID}:${userToken}`,
-                  "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ appId: "gmail", userId }),
-              }
-            );
-
-            if (checkResponse.ok) {
-              console.log(`\n\n✅ Permission granted! Continuing...\n`);
-              tokenAvailable = true;
-            }
-          } catch (error) {
-            // Keep polling
-          }
+          messages.push({
+            role: "user",
+            content: [{
+              type: "tool_result",
+              tool_use_id: toolUse.id,
+              content: "Permission granted. Please retry.",
+            }],
+          });
+          continue;
         }
-
-        if (!tokenAvailable) {
-          console.log(`\n\n❌ Timeout. Please try again.\n`);
-          messages.push({
-            role: "user",
-            content: [{
-              type: "tool_result",
-              tool_use_id: toolUse.id,
-              content: `Timeout waiting for permission.`,
-              is_error: true,
-            }],
-          });
-        } else if (toolUse.name === "send_gmail_email") {
-          messages.push({
-            role: "user",
-            content: [{
-              type: "tool_result",
-              tool_use_id: toolUse.id,
-              content: `Gmail send permission granted. Let the user know they can now ask you to send the email again.`,
-            }],
-          });
-        } else {
-          messages.push({
-            role: "user",
-            content: [{
-              type: "tool_result",
-              tool_use_id: toolUse.id,
-              content: `Permission granted. Retrying...`,
-            }],
-          });
-        }
-        continue;
       }
 
+      // ── Normal result ──────────────────────────────────────────────────
       messages.push({
         role: "user",
         content: [{


### PR DESCRIPTION
## Related Issues

Fixes <link_to_github_issue>

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |


## Description

Updates the Claude Gmail agent example with the following:

- MCP authentication via Descope's OAuth 2.0 consent flow
- Connection-time scope verification (rejects clients missing google-read before any tool is called)
- Progressive OAuth scoping for gmail.readonly and gmail.send
- Human-in-the-loop email approval via Descope Enchanted Link
- Updated README with setup instructions and environment variable reference

The MCP server is based on the Descope Next.js MCP template and deployed separately on Vercel.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
