### PR TITLE
Add Meridian B2B travel & expense MCP server example

### DIFF
--- a/examples/b2b-mcp-server/.dockerignore
+++ b/examples/b2b-mcp-server/.dockerignore
@@ -1,0 +1,60 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+
+# Docker
+Dockerfile
+.dockerignore
+
+# Logs
+*.log
+
+# Documentation
+README.md 

--- a/examples/b2b-mcp-server/.env.example
+++ b/examples/b2b-mcp-server/.env.example
@@ -1,0 +1,10 @@
+# The .well-known URL of your Descope MCP Server.
+# Copy it from the Descope Console -> Agentic Identity Hub -> MCP Servers.
+# Example shape (yours will use your project + MCP server IDs, or a custom domain):
+DESCOPE_CONFIG_URL=https://api.descope.com/v1/apps/agentic/<project-id>/<mcp-server-id>/.well-known/openid-configuration
+
+# The public URL where this server is reachable
+SERVER_URL=http://localhost:8000
+
+# Port to listen on (optional, defaults to 8000)
+PORT=8000

--- a/examples/b2b-mcp-server/.gitignore
+++ b/examples/b2b-mcp-server/.gitignore
@@ -1,0 +1,5 @@
+.env
+.venv/
+__pycache__/
+*.py[cod]
+uv.lock

--- a/examples/b2b-mcp-server/Dockerfile
+++ b/examples/b2b-mcp-server/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Copy dependency manifests first for better layer caching
+COPY pyproject.toml requirements.txt ./
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+ENV PORT=8000
+
+EXPOSE 8000
+
+# Health check hits the landing page route
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import os,urllib.request; urllib.request.urlopen(f'http://localhost:{os.getenv(\"PORT\",\"8000\")}/')" || exit 1
+
+CMD ["python", "server.py"]

--- a/examples/b2b-mcp-server/README.md
+++ b/examples/b2b-mcp-server/README.md
@@ -15,11 +15,17 @@ It's built to be a **demo of Descope's B2B capabilities for MCP auth**. Unlike a
 consumer (B2C) app, a B2B product is organized around *organizations* (tenants)
 and *roles*. This server shows both:
 
-1. **Multi-tenant isolation.** Every request carries a Descope-issued JWT that
-   identifies the caller's **organization**. Every tool reads and writes only
-   that tenant's data. Acme Robotics' agent can never see Globex Corporation's
-   expenses, even though both connect to the same server. Two demo tenants are
-   seeded so you can prove it.
+1. **Multi-tenant isolation.** Descope provides the **auth layer**, not your data
+   layer — it doesn't store or return your tenants' records. What it does is
+   authenticate the request and stamp the caller's **organization** into the
+   token via the **`dct` claim** (the "current tenant"). Your MCP server reads
+   `dct` off the validated token and is responsible for scoping every query to
+   that tenant. In this example, `_current_tenant()` reads the claim and each
+   tool only touches that org's in-memory data — so Acme Robotics' agent never
+   sees Globex Corporation's expenses, even though both connect to the same
+   server. Two demo tenants are seeded so you can prove it. Swap the in-memory
+   store for your real database and you'd apply the same `dct`-based filter (a
+   `WHERE tenant_id = …`, a per-tenant schema, etc.).
 2. **Role-based authorization (tool-level scopes).** Each tool declares the OAuth
    scope(s) it needs. A caller whose token lacks a scope won't even see the tool
    in `tools/list`, and a direct call returns _not found_. Roles map to scope
@@ -87,16 +93,22 @@ auth_provider = DescopeProvider(
 mcp = FastMCP(name="Meridian Travel & Expense MCP Server", auth=auth_provider)
 ```
 
-**Tenant isolation.** Each tool resolves the caller's organization from the
-validated token before touching data:
+**Tenant isolation (your responsibility, using Descope's claim).** Descope puts
+the caller's tenant in the token's **`dct` claim**; the server reads it and scopes
+its own data access. Descope never sees or returns your business data — it just
+tells you *which tenant* the request belongs to:
 
 ```python
 from fastmcp.server.dependencies import get_access_token
 
 def _current_tenant() -> str:
     claims = get_access_token().claims or {}
-    # Descope multi-tenant tokens carry `dct` (selected tenant) and a `tenants` map.
+    # Descope stamps the caller's tenant into the token as `dct` ("current
+    # tenant"); multi-tenant tokens also carry a `tenants` map. Your code reads
+    # this and does the data scoping — Descope doesn't touch your data.
     return claims.get("dct") or next(iter(claims.get("tenants", {})), DEFAULT_TENANT)
+
+# ...then every tool filters on it, e.g. rows WHERE tenant_id == _current_tenant().
 ```
 
 **Authorization (per tool).** Each tool declares its scope:

--- a/examples/b2b-mcp-server/README.md
+++ b/examples/b2b-mcp-server/README.md
@@ -1,0 +1,295 @@
+# Meridian — a B2B Travel & Expense MCP Server (Python)
+
+![Descope Banner](https://github.com/descope/.github/assets/32936811/d904d37e-e3fa-4331-9f10-2880bb708f64)
+
+## Introduction
+
+**Meridian** is a fictional B2B SaaS company — a corporate **travel & expense**
+platform in the spirit of Navan, Ramp, Brex, or Box. This example wraps
+Meridian's product surface in a [FastMCP 3](https://gofastmcp.com/) server and
+secures it with [Descope](https://www.descope.com/), so an AI agent can book
+travel, file expenses, approve reports, and pull spend analytics on a user's
+behalf.
+
+It's built to be a **demo of Descope's B2B capabilities for MCP auth**. Unlike a
+consumer (B2C) app, a B2B product is organized around *organizations* (tenants)
+and *roles*. This server shows both:
+
+1. **Multi-tenant isolation.** Every request carries a Descope-issued JWT that
+   identifies the caller's **organization**. Every tool reads and writes only
+   that tenant's data. Acme Robotics' agent can never see Globex Corporation's
+   expenses, even though both connect to the same server. Two demo tenants are
+   seeded so you can prove it.
+2. **Role-based authorization (tool-level scopes).** Each tool declares the OAuth
+   scope(s) it needs. A caller whose token lacks a scope won't even see the tool
+   in `tools/list`, and a direct call returns _not found_. Roles map to scope
+   bundles, so an Employee, a Manager, and a Finance Admin each see a different
+   toolset.
+
+The store is in-memory, so it runs with no external dependencies. Swap it for a
+real per-tenant database and the identity model is unchanged.
+
+## The B2B model: roles → scopes → tools
+
+Meridian defines these OAuth scopes (configure them on your Descope MCP Server):
+
+| Scope              | Grants                                            |
+| ------------------ | ------------------------------------------------- |
+| `expenses:read`    | View expense reports                              |
+| `expenses:write`   | Submit expense reports                            |
+| `expenses:approve` | Approve / reject expenses (Manager)               |
+| `trips:read`       | Search flights, list trips                        |
+| `trips:book`       | Book travel                                       |
+| `reports:read`     | Spend analytics (Manager)                         |
+| `admin`            | Org directory, budgets, travel policy (Finance)   |
+
+A typical B2B role → scope mapping:
+
+| Role              | Scopes                                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------ |
+| **Employee**      | `expenses:read` `expenses:write` `trips:read` `trips:book`                                 |
+| **Manager**       | Employee + `expenses:approve` `reports:read`                                               |
+| **Finance Admin** | Manager + `admin`                                                                          |
+
+### Tools and the scopes they require
+
+| Tool                | Required scope     | Description                                     |
+| ------------------- | ------------------ | ----------------------------------------------- |
+| `whoami`            | _(any authed)_     | Show caller identity, organization, and scopes  |
+| `list_expenses`     | `expenses:read`    | List your org's expenses (optional status filter) |
+| `get_expense`       | `expenses:read`    | Fetch one expense by id                         |
+| `submit_expense`    | `expenses:write`   | File a new expense (policy sets auto-approval)  |
+| `approve_expense`   | `expenses:approve` | Approve a pending expense                       |
+| `reject_expense`    | `expenses:approve` | Reject a pending expense with a reason          |
+| `search_flights`    | `trips:read`       | Search in-policy flights                        |
+| `list_trips`        | `trips:read`       | List booked trips                               |
+| `book_trip`         | `trips:book`       | Book a trip (enforced against policy)           |
+| `expense_summary`   | `reports:read`     | Org spend analytics + budget utilization        |
+| `list_employees`    | `admin`            | Organization directory                          |
+| `set_travel_policy` | `admin`            | Update the org's travel/expense policy          |
+
+## How the two layers work
+
+**Authentication (server-wide).** The `DescopeProvider` points at your Descope
+**MCP Server**'s `.well-known` URL. It discovers Descope's endpoints, validates
+every request's JWT against Descope's JWKS, and serves the OAuth 2.1 discovery
+routes. In FastMCP 3, configuring an auth provider rejects unauthenticated
+requests at the transport layer automatically.
+
+```python
+from fastmcp import FastMCP
+from fastmcp.server.auth.providers.descope import DescopeProvider
+
+auth_provider = DescopeProvider(
+    config_url="https://.../.well-known/openid-configuration",  # Your MCP Server .well-known URL
+    base_url=SERVER_URL,                                        # Your server's public URL
+)
+mcp = FastMCP(name="Meridian Travel & Expense MCP Server", auth=auth_provider)
+```
+
+**Tenant isolation.** Each tool resolves the caller's organization from the
+validated token before touching data:
+
+```python
+from fastmcp.server.dependencies import get_access_token
+
+def _current_tenant() -> str:
+    claims = get_access_token().claims or {}
+    # Descope multi-tenant tokens carry `dct` (selected tenant) and a `tenants` map.
+    return claims.get("dct") or next(iter(claims.get("tenants", {})), DEFAULT_TENANT)
+```
+
+**Authorization (per tool).** Each tool declares its scope:
+
+```python
+from fastmcp.server.auth import require_scopes
+
+@mcp.tool(auth=require_scopes("expenses:approve"))
+async def approve_expense(expense_id: int) -> str:
+    ...
+```
+
+- **Single scope:** `require_scopes("expenses:read")`
+- **Multiple scopes (AND):** `require_scopes("expenses:write", "expenses:approve")`
+- **No scope:** omit `auth` for a tool any authenticated caller can use (`whoami`).
+
+Descope handles Dynamic Client Registration (DCR), so MCP clients register and
+request scopes automatically. The scopes the user consents to are embedded in the
+issued token and checked per tool.
+
+## Enterprise-managed access with ID-JAG (Cross-App Access)
+
+The flow above is the standard interactive OAuth path: a user connects a client,
+gets redirected to consent, and a token is minted. That's great for self-serve
+adoption — but inside a large enterprise, IT wants to *centrally* govern which AI
+apps may reach which internal MCP servers, without every employee doing a
+per-app OAuth dance.
+
+Descope supports exactly that for Meridian's MCP server through **ID-JAG**
+(Identity Assertion Authorization Grant), the token type behind
+**Cross-App Access (XAA)** and the MCP spec's
+[Enterprise-Managed Authorization extension](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization)
+(SEP-990, MCP 2025-11-25). This is the path used when **Claude is deployed
+internally with a workforce IdP**: an admin authorizes the client (Claude,
+Claude Code, Cowork) once, at the IdP, and users get Meridian already connected
+on first login — no separate consent screen.
+
+**How it works.** ID-JAG lets your enterprise identity provider (Okta, Entra ID,
+etc.) issue a short-lived, signed assertion that a given client may act for a
+given user at a specific resource — here, Meridian's MCP server. The full
+exchange:
+
+1. The user signs in to the client through the workforce IdP via SSO (OIDC),
+   receiving an ID token.
+2. The client exchanges that ID token for an **ID-JAG** at the IdP's token
+   endpoint using OAuth token exchange
+   ([RFC 8693](https://www.rfc-editor.org/rfc/rfc8693)). The IdP applies company
+   policy — is this app allowed to call Meridian, with these scopes?
+3. The client presents the ID-JAG to **Descope** (Meridian's authorization
+   server) using the JWT-bearer grant
+   ([RFC 7523](https://www.rfc-editor.org/rfc/rfc7523)):
+   `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer`.
+4. Descope validates the assertion against the **trusted IdP** configured on your
+   tenant and mints a short-lived Meridian access token — the same kind of Descope
+   token this server already validates, carrying the tenant and scopes. Your tool
+   code (`_current_tenant()`, `require_scopes(...)`) does not change at all.
+5. The client calls Meridian's `/mcp` endpoint with that access token until it
+   expires.
+
+**Enabling it in your tenant.** ID-JAG exchange is enabled per **tenant** in
+Descope — the same tenant construct this server already uses for isolation. In
+the [Descope Console](https://app.descope.com), under **Agentic Identity Hub →
+MCP Servers**, turn on ID-JAG / Cross-App Access for Meridian's MCP server and
+register the enterprise **IdP you trust to issue assertions** for that tenant
+(e.g. the customer's Okta or Entra tenant). Once trusted, ID-JAG tokens minted by
+that IdP can be exchanged for access tokens to this MCP server; ID-JAG from any
+untrusted issuer is rejected. Because trust is scoped to the tenant, Acme can
+authorize its own IdP without granting Globex's IdP any access.
+
+> This complements — it doesn't replace — the interactive OAuth + DCR flow. The
+> same MCP server can serve self-serve users (interactive consent) and enterprise
+> workforce users (IdP-governed, zero-touch via ID-JAG) at once.
+
+See the [Descope MCP Authorization docs](https://docs.descope.com/mcp) for the
+current console steps.
+
+## Requirements
+
+- Python 3.12+
+- FastMCP 3.4+
+- An [MCP Server](https://docs.descope.com/agentic-identity-hub/mcp-servers/settings)
+  configured in Descope (with the scopes above) and its `.well-known` URL
+- For the multi-tenant demo: at least one **tenant** (and, ideally, roles) set up
+  in your Descope project
+- For the enterprise / workforce demo (Claude internal): ID-JAG / Cross-App Access
+  enabled on the tenant, with a trusted enterprise IdP (see below)
+
+## Descope setup
+
+1. In the [Descope Console](https://app.descope.com), go to **Agentic Identity
+   Hub → [MCP Servers](https://docs.descope.com/agentic-identity-hub/mcp-servers/settings)**
+   and create an MCP Server.
+2. Add the **scopes** listed above (`expenses:read`, `expenses:write`, … `admin`).
+3. (For the tenant demo) Create **tenants** — e.g. one named `acme-robotics` and
+   one named `globex` — and assign your test users to them. The seeded data in
+   this server uses those tenant ids; a token for any other tenant still works,
+   it just starts with an empty (auto-created) org.
+4. Copy the MCP Server's **`.well-known` (OpenID configuration) URL**.
+
+## Quick Start
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/descope/ai.git
+cd ai/examples/b2b-mcp-server
+```
+
+### 2. Set up environment variables
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env`:
+
+```env
+# Your Descope MCP Server's .well-known URL (Console -> Agentic Identity Hub -> MCP Servers)
+DESCOPE_CONFIG_URL=https://api.descope.com/v1/apps/agentic/<project-id>/<mcp-server-id>/.well-known/openid-configuration
+# The public URL where this server is reachable
+SERVER_URL=http://localhost:8000
+# Port to listen on (optional)
+PORT=8000
+```
+
+### 3. Install dependencies
+
+```bash
+uv sync
+```
+
+(Or with pip: `pip install -r requirements.txt`.)
+
+### 4. Run the server
+
+```bash
+uv run python server.py
+```
+
+### 5. Open the landing page
+
+Visit [http://localhost:8000](http://localhost:8000) for the company overview,
+tool/scope reference, and connection config.
+
+## Connecting a client
+
+Point any MCP client at the server URL and let it complete the OAuth flow:
+
+```json
+{
+  "mcpServers": {
+    "meridian": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
+## Seeing it in action (demo script)
+
+1. **Show identity.** Ask the agent to call `whoami` → it reports the subject,
+   the **organization** the token belongs to, and the granted scopes.
+2. **Role scoping.** Connect as an **Employee** → you can `submit_expense`,
+   `search_flights`, and `book_trip`, but `approve_expense`, `expense_summary`,
+   and `list_employees` are hidden. Re-connect as a **Manager** → approvals and
+   reporting appear. As a **Finance Admin** → the `admin` tools appear.
+3. **Tenant isolation.** Connect with an **Acme** token and `list_expenses` — you
+   see Acme's data. Connect with a **Globex** token and you see only Globex's.
+   The same server, the same tools, strictly separated data.
+4. **Policy in the loop.** `set_travel_policy` (admin) lowers the flight cap, then
+   `search_flights` and `book_trip` immediately enforce the new limit.
+
+## API Endpoints
+
+- `GET /` — Landing page and documentation
+- `POST /mcp` — Main MCP endpoint (requires a Bearer token)
+- `GET /.well-known/oauth-protected-resource/mcp` — Resource metadata for the `/mcp` endpoint
+- `GET /.well-known/oauth-authorization-server` — OAuth 2.1 server metadata (discovered from Descope)
+
+## Troubleshooting
+
+- **A tool is missing.** By design when your token lacks its scope. Confirm the
+  scope exists on your Descope MCP Server and was requested by the client (decode
+  your access token to inspect its scopes).
+- **`whoami` shows the wrong / default org.** Your token isn't carrying a tenant
+  claim. Assign the user to a tenant in Descope and ensure the token includes it
+  (`dct` or the `tenants` map).
+- **Authentication errors.** Clear cached auth state: `rm -rf ~/.mcp-auth`, and
+  verify `DESCOPE_CONFIG_URL` points at your MCP Server's `.well-known` URL.
+
+## Learn more
+
+- [FastMCP Authorization docs](https://gofastmcp.com/servers/authorization)
+- [FastMCP Descope integration](https://gofastmcp.com/integrations/descope)
+- [Descope MCP Authorization](https://docs.descope.com/mcp)
+- [Descope MCP Servers](https://docs.descope.com/agentic-identity-hub/mcp-servers/settings)

--- a/examples/b2b-mcp-server/brand/README.md
+++ b/examples/b2b-mcp-server/brand/README.md
@@ -1,0 +1,41 @@
+# Meridian brand assets
+
+Logo files for the fictional **Meridian** company used in this demo. The mark is
+a *meridian globe* — a globe crossed by a meridian line and equator, topped by
+the diamond marker used across the landing page — in the Descope purple → indigo
+→ pink gradient.
+
+| File | Use |
+| --- | --- |
+| `logo-mark.svg` | Icon / mark only (64×64, transparent). Primary asset — font-independent, scales anywhere. Use this as the **Descope project logo**. |
+| `favicon.svg` | The mark on a dark rounded tile. Browser tab / app icon, and good where a solid background reads better than a transparent mark. |
+| `logo-full-dark.svg` | Horizontal lockup (mark + "Meridian") for **dark** backgrounds — e.g. the landing page. |
+| `logo-full-light.svg` | Horizontal lockup for **light** backgrounds — e.g. a hosted login page. |
+
+## Colors
+
+- Purple `#8B5CF6` · Indigo `#6366F1` · Pink `#EC4899` (accent / diamond)
+- Light purple `#A78BFA` · Dark surface `#111827` · Border `#374151`
+
+## Fonts (wordmark)
+
+The lockups set the wordmark in **Barlow Semi Condensed** (600), falling back to
+Barlow / Arial. The landing page already loads that font, so the inline nav mark
+renders exactly. For a fully self-contained lockup that renders identically with
+no font installed, outline the `<text>` to paths in your vector editor.
+
+## Using it as the Descope project logo
+
+The project `P3GC1znDUdJvIpvZLDdUTMk08nMk` wasn't reachable from the account this
+session's Descope MCP is authenticated as, so these files weren't uploaded for
+you. To apply the logo yourself:
+
+1. In the [Descope Console](https://app.descope.com), open the target project.
+2. **Project branding / theme:** Settings → Project → Branding (or the Flows
+   theme editor) → upload `logo-mark.svg` (or `favicon.svg`) as the logo.
+3. **Hosted login / Flows:** in the Flow editor's theme/branding panel, set the
+   logo image to `logo-mark.svg`; use `logo-full-light.svg` anywhere a full
+   wordmark fits on a light background.
+
+SVG is accepted for most logo slots; if a slot requires PNG, export at 512×512
+(mark) or 2× the display size (lockups) from any vector tool or a browser.

--- a/examples/b2b-mcp-server/brand/favicon.svg
+++ b/examples/b2b-mcp-server/brand/favicon.svg
@@ -1,0 +1,16 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Meridian">
+  <title>Meridian</title>
+  <defs>
+    <linearGradient id="fg" x1="16" y1="14" x2="50" y2="52" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#A78BFA"/>
+      <stop offset="0.55" stop-color="#8B5CF6"/>
+      <stop offset="1" stop-color="#EC4899"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="15" fill="#111827"/>
+  <rect x="0.5" y="0.5" width="63" height="63" rx="14.5" stroke="#374151"/>
+  <path d="M16 33 H48" stroke="url(#fg)" stroke-width="2.6" stroke-linecap="round" opacity="0.55"/>
+  <ellipse cx="32" cy="33" rx="7" ry="16" stroke="url(#fg)" stroke-width="2.6"/>
+  <circle cx="32" cy="33" r="16" stroke="url(#fg)" stroke-width="3.2"/>
+  <rect x="27.8" y="12.8" width="8.4" height="8.4" rx="1.5" transform="rotate(45 32 17)" fill="#EC4899"/>
+</svg>

--- a/examples/b2b-mcp-server/brand/logo-full-dark.svg
+++ b/examples/b2b-mcp-server/brand/logo-full-dark.svg
@@ -1,0 +1,20 @@
+<svg width="248" height="64" viewBox="0 0 248 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Meridian">
+  <title>Meridian</title>
+  <defs>
+    <linearGradient id="mgd" x1="12" y1="10" x2="54" y2="56" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8B5CF6"/>
+      <stop offset="0.55" stop-color="#6366F1"/>
+      <stop offset="1" stop-color="#EC4899"/>
+    </linearGradient>
+    <radialGradient id="mfd" cx="40%" cy="34%" r="72%">
+      <stop stop-color="#8B5CF6" stop-opacity="0.20"/>
+      <stop offset="1" stop-color="#EC4899" stop-opacity="0.05"/>
+    </radialGradient>
+  </defs>
+  <circle cx="32" cy="34" r="20" fill="url(#mfd)"/>
+  <path d="M12.5 34 H51.5" stroke="url(#mgd)" stroke-width="2.4" stroke-linecap="round" opacity="0.5"/>
+  <ellipse cx="32" cy="34" rx="8" ry="20" stroke="url(#mgd)" stroke-width="2.4"/>
+  <circle cx="32" cy="34" r="20" stroke="url(#mgd)" stroke-width="3"/>
+  <rect x="27.4" y="9.4" width="9.2" height="9.2" rx="1.6" transform="rotate(45 32 14)" fill="#EC4899"/>
+  <text x="76" y="42" font-family="'Barlow Semi Condensed', 'Barlow', Arial, sans-serif" font-size="34" font-weight="600" letter-spacing="-0.3" fill="#F3F4F6">Meridian</text>
+</svg>

--- a/examples/b2b-mcp-server/brand/logo-full-light.svg
+++ b/examples/b2b-mcp-server/brand/logo-full-light.svg
@@ -1,0 +1,20 @@
+<svg width="248" height="64" viewBox="0 0 248 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Meridian">
+  <title>Meridian</title>
+  <defs>
+    <linearGradient id="mgl" x1="12" y1="10" x2="54" y2="56" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8B5CF6"/>
+      <stop offset="0.55" stop-color="#6366F1"/>
+      <stop offset="1" stop-color="#EC4899"/>
+    </linearGradient>
+    <radialGradient id="mfl" cx="40%" cy="34%" r="72%">
+      <stop stop-color="#8B5CF6" stop-opacity="0.16"/>
+      <stop offset="1" stop-color="#EC4899" stop-opacity="0.04"/>
+    </radialGradient>
+  </defs>
+  <circle cx="32" cy="34" r="20" fill="url(#mfl)"/>
+  <path d="M12.5 34 H51.5" stroke="url(#mgl)" stroke-width="2.4" stroke-linecap="round" opacity="0.5"/>
+  <ellipse cx="32" cy="34" rx="8" ry="20" stroke="url(#mgl)" stroke-width="2.4"/>
+  <circle cx="32" cy="34" r="20" stroke="url(#mgl)" stroke-width="3"/>
+  <rect x="27.4" y="9.4" width="9.2" height="9.2" rx="1.6" transform="rotate(45 32 14)" fill="#EC4899"/>
+  <text x="76" y="42" font-family="'Barlow Semi Condensed', 'Barlow', Arial, sans-serif" font-size="34" font-weight="600" letter-spacing="-0.3" fill="#1F2937">Meridian</text>
+</svg>

--- a/examples/b2b-mcp-server/brand/logo-mark.svg
+++ b/examples/b2b-mcp-server/brand/logo-mark.svg
@@ -1,0 +1,19 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Meridian">
+  <title>Meridian</title>
+  <defs>
+    <linearGradient id="mg" x1="12" y1="10" x2="54" y2="56" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8B5CF6"/>
+      <stop offset="0.55" stop-color="#6366F1"/>
+      <stop offset="1" stop-color="#EC4899"/>
+    </linearGradient>
+    <radialGradient id="mfill" cx="40%" cy="34%" r="72%">
+      <stop stop-color="#8B5CF6" stop-opacity="0.20"/>
+      <stop offset="1" stop-color="#EC4899" stop-opacity="0.05"/>
+    </radialGradient>
+  </defs>
+  <circle cx="32" cy="34" r="20" fill="url(#mfill)"/>
+  <path d="M12.5 34 H51.5" stroke="url(#mg)" stroke-width="2.4" stroke-linecap="round" opacity="0.5"/>
+  <ellipse cx="32" cy="34" rx="8" ry="20" stroke="url(#mg)" stroke-width="2.4"/>
+  <circle cx="32" cy="34" r="20" stroke="url(#mg)" stroke-width="3"/>
+  <rect x="27.4" y="9.4" width="9.2" height="9.2" rx="1.6" transform="rotate(45 32 14)" fill="#EC4899"/>
+</svg>

--- a/examples/b2b-mcp-server/index.html
+++ b/examples/b2b-mcp-server/index.html
@@ -1,489 +1,635 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Meridian — Travel &amp; Expense MCP Server</title>
-    <script>
-      const SERVER_URL = window.location.origin + "/mcp";
-    </script>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script>
-      tailwind.config = {
-        darkMode: "class",
-        theme: {
-          extend: {
-            colors: {
-              primary: "#8B5CF6", // Purple
-              secondary: "#6366F1", // Indigo
-              accent: "#EC4899", // Pink
-              dark: {
-                DEFAULT: "#111827",
-                lighter: "#1F2937",
-              },
-            },
-            fontFamily: {
-              sans: ["Inter", "system-ui", "sans-serif"],
-              heading: ["Space Grotesk", "system-ui", "sans-serif"],
-            },
-          },
-        },
-      };
-    </script>
-    <style>
-      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap");
+<html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Meridian MCP Server · Corporate Travel &amp; Expense</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Barlow:wght@300;400;500;600;700&family=Barlow+Semi+Condensed:wght@500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap">
 
-      body {
-        background-color: #111827;
-        color: #f3f4f6;
-      }
+<style>
+  :root {
+    --purple: #8B5CF6;
+    --purple-2: #A78BFA;
+    --indigo: #6366F1;
+    --pink: #EC4899;
+    --bg: #111827;
+    --bg-2: #0d1320;
+    --card: #1F2937;
+    --card-2: #232f42;
+    --border: #374151;
+    --border-soft: #2b3648;
+    --text: #F3F4F6;
+    --text-dim: #9CA3AF;
+    --text-mute: #6B7280;
+    --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    --sans: "Barlow", Arial, Helvetica, sans-serif;
+    --cond: "Barlow Semi Condensed", var(--sans);
+    --maxw: 1140px;
+  }
 
-      pre {
-        background: #1f2937 !important;
-        color: #e5e7eb !important;
-        position: relative;
-        white-space: pre-wrap;
-        word-wrap: break-word;
-        word-break: break-word;
-        border-radius: 0.5rem;
-        padding: 0.7rem;
-        border: 1px solid #374151;
-        text-shadow: none;
-        -webkit-text-fill-color: #e5e7eb;
-      }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 1.6;
+    overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
+  }
+  ::selection { background: rgba(139,92,246,0.32); }
 
-      pre code {
-        background: transparent !important;
-        color: inherit !important;
-        text-shadow: none;
-        -webkit-text-fill-color: inherit;
-      }
+  a { color: var(--purple-2); text-decoration: none; transition: color .18s ease; }
+  a:hover { color: var(--pink); }
 
-      pre .copy-button {
-        position: absolute;
-        top: 0.5rem;
-        right: 0.5rem;
-        padding: 0.25rem 0.5rem;
-        background: rgba(139, 92, 246, 0.1);
-        border: 1px solid rgba(139, 92, 246, 0.2);
-        color: #8b5cf6;
-        border-radius: 0.25rem;
-        cursor: pointer;
-        font-size: 0.75rem;
-        transition: all 0.2s;
-      }
+  h1, h2, h3, h4 { font-family: var(--sans); font-weight: 600; letter-spacing: -0.015em; line-height: 1.14; margin: 0; }
+  p { margin: 0; }
+  code, pre { font-family: var(--mono); }
 
-      pre .copy-button:hover {
-        background: rgba(139, 92, 246, 0.2);
-      }
+  .wrap { width: 100%; max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
 
-      pre .copy-button.copied {
-        background: rgba(139, 92, 246, 0.2);
-        border-color: rgba(139, 92, 246, 0.2);
-      }
+  /* ---------- ambient background: meridian lines, not glow ---------- */
+  .bg-fx { position: fixed; inset: 0; z-index: 0; pointer-events: none; overflow: hidden; }
+  .bg-fx .halo {
+    position: absolute; top: -280px; left: 50%; transform: translateX(-50%);
+    width: 900px; height: 620px;
+    background: radial-gradient(ellipse at center, rgba(99,102,241,0.16), transparent 62%);
+  }
+  .bg-fx .grid-lines {
+    position: absolute; inset: 0;
+    background-image: linear-gradient(rgba(148,163,184,0.045) 1px, transparent 1px),
+                      linear-gradient(90deg, rgba(148,163,184,0.045) 1px, transparent 1px);
+    background-size: 60px 60px;
+    -webkit-mask-image: radial-gradient(ellipse 80% 50% at 50% 0%, black, transparent 76%);
+            mask-image: radial-gradient(ellipse 80% 50% at 50% 0%, black, transparent 76%);
+  }
+  /* the meridian: a single bright latitude line under the hero */
+  .bg-fx .meridian {
+    position: absolute; top: 560px; left: 0; right: 0; height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(139,92,246,0.5) 30%, rgba(236,72,153,0.5) 70%, transparent);
+  }
+  .bg-fx .meridian::before {
+    content: ""; position: absolute; left: 50%; top: -3px; width: 7px; height: 7px;
+    transform: translateX(-50%) rotate(45deg); background: var(--purple-2);
+  }
 
-      .card {
-        background: #1f2937;
-        border: 1px solid #374151;
-        transition: all 0.2s;
-      }
+  main { position: relative; z-index: 1; }
 
-      .card:hover {
-        border-color: #8b5cf6;
-      }
+  /* ---------- nav ---------- */
+  nav { position: sticky; top: 0; z-index: 50; background: rgba(17,24,39,0.86); border-bottom: 1px solid var(--border-soft); }
+  nav .wrap { display: flex; align-items: center; justify-content: space-between; height: 66px; }
+  .brand { display: flex; align-items: center; gap: 12px; font-family: var(--cond); font-weight: 600; font-size: 20px; letter-spacing: 0.01em; }
+  .brand .mark { width: 32px; height: 32px; border: 1px solid var(--border); border-radius: 8px; display: grid; place-items: center; background: var(--card); position: relative; }
+  .brand .mark svg { width: 19px; height: 19px; }
+  .nav-links { display: flex; align-items: center; gap: 28px; }
+  .nav-links a { color: var(--text-dim); font-size: 14px; font-weight: 500; }
+  .nav-links a:hover { color: var(--text); }
+  .nav-badge {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--mono); font-size: 12px; font-weight: 500; color: var(--text-dim);
+    padding: 6px 13px; border: 1px solid var(--border); border-radius: 999px; background: var(--card);
+  }
+  .nav-badge .dot { width: 7px; height: 7px; border-radius: 50%; background: #34D399; box-shadow: 0 0 8px #34D399; }
+  @media (max-width: 760px) { .nav-links a:not(.nav-badge) { display: none; } }
 
-      code {
-        background: #374151;
-        color: #e5e7eb;
-      }
+  /* ---------- buttons: Descope pill signature, no glow ---------- */
+  .btn {
+    display: inline-flex; align-items: center; gap: 10px; position: relative;
+    font-family: var(--sans); font-size: 15px; font-weight: 600; cursor: pointer;
+    padding: 13px 24px; border-radius: 999px; border: 1px solid transparent;
+    transition: background .2s ease, border-color .2s ease, color .2s ease;
+  }
+  .btn .arw { transition: transform .2s ease; }
+  .btn:hover .arw { transform: translateX(4px); }
+  .btn-primary { background: var(--purple); color: #fff; }
+  .btn-primary:hover { background: #7c4ef0; color: #fff; }
+  .btn-ghost { background: transparent; border-color: var(--border); color: var(--text); }
+  .btn-ghost:hover { border-color: var(--purple); color: var(--text); background: rgba(139,92,246,0.08); }
 
-      .scope-badge {
-        display: inline-block;
-        font-size: 0.7rem;
-        font-weight: 600;
-        padding: 0.1rem 0.5rem;
-        border-radius: 9999px;
-        border: 1px solid rgba(139, 92, 246, 0.4);
-        background: rgba(139, 92, 246, 0.12);
-        color: #c4b5fd;
-        font-family: ui-monospace, monospace;
-      }
+  /* ---------- hero ---------- */
+  .hero { padding: 90px 0 68px; text-align: center; }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 10px;
+    font-family: var(--mono); font-size: 12px; font-weight: 500; letter-spacing: 0.02em;
+    color: var(--text-dim); text-transform: uppercase;
+    padding: 7px 6px 7px 14px; border: 1px solid var(--border); border-radius: 999px; background: var(--card);
+    margin-bottom: 30px;
+  }
+  .eyebrow .code { font-weight: 600; color: var(--purple-2); background: rgba(139,92,246,0.14); border-radius: 999px; padding: 3px 10px; letter-spacing: 0.06em; }
+  .hero h1 {
+    font-family: var(--cond); font-size: clamp(42px, 7vw, 74px); font-weight: 600; letter-spacing: -0.01em; line-height: 1.02;
+    margin: 0 auto 26px; max-width: 16ch;
+  }
+  .hero h1 .accent { color: var(--purple-2); }
+  .lede { font-size: clamp(17px, 2.2vw, 20px); color: var(--text-dim); max-width: 60ch; margin: 0 auto 20px; line-height: 1.6; }
+  .lede strong { color: var(--text); font-weight: 600; }
+  .hero-sub { font-size: 15.5px; color: var(--text-mute); max-width: 66ch; margin: 0 auto 34px; line-height: 1.66; }
+  .hero-sub .hl { color: var(--text-dim); }
+  .hero-cta { display: flex; flex-wrap: wrap; gap: 14px; justify-content: center; align-items: center; margin-bottom: 26px; }
+  .meta-row { display: flex; flex-wrap: wrap; gap: 10px 22px; justify-content: center; align-items: center; }
+  .meta-chip { display: inline-flex; align-items: center; gap: 9px; font-family: var(--mono); font-size: 12.5px; color: var(--text-mute); }
+  .meta-chip b { color: var(--text-dim); font-weight: 600; }
+  .meta-chip .tick { color: var(--purple); }
+  .meta-chip.demo { padding: 6px 13px; border: 1px dashed var(--border); border-radius: 999px; }
 
-      .role-chip {
-        display: inline-block;
-        font-size: 0.75rem;
-        font-weight: 600;
-        padding: 0.15rem 0.6rem;
-        border-radius: 9999px;
-        border: 1px solid #374151;
-        background: #111827;
-        color: #e5e7eb;
-      }
+  /* ---------- section scaffolding + numbered overlines ---------- */
+  section.block { padding: 62px 0; }
+  .sec-head { max-width: 720px; margin-bottom: 42px; }
+  .sec-head.center { margin-left: auto; margin-right: auto; text-align: center; }
+  .overline {
+    display: inline-flex; align-items: baseline; gap: 12px;
+    font-family: var(--mono); font-size: 13px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--text-dim); margin-bottom: 16px;
+  }
+  .overline .idx { color: var(--purple-2); }
+  .overline .rule { display: inline-block; width: 34px; height: 1px; background: var(--border); transform: translateY(-4px); }
+  .sec-head.center .overline { justify-content: center; }
+  .sec-head h2 { font-family: var(--cond); font-size: clamp(30px, 4vw, 44px); font-weight: 600; margin-bottom: 15px; letter-spacing: -0.01em; }
+  .sec-head p { color: var(--text-dim); font-size: 16.5px; line-height: 1.62; }
 
-      a {
-        color: #8b5cf6;
-        transition: all 0.2s;
-        text-decoration: underline !important;
-      }
+  /* ---------- corner-bracket card motif (the "unique borders") ---------- */
+  .card { position: relative; background: var(--card); border: 1px solid var(--border); }
+  .card::before, .card::after {
+    content: ""; position: absolute; width: 13px; height: 13px; pointer-events: none;
+    transition: border-color .2s ease; opacity: .9;
+  }
+  .card::before { top: 9px; left: 9px; border-top: 1.5px solid var(--text-mute); border-left: 1.5px solid var(--text-mute); }
+  .card::after { bottom: 9px; right: 9px; border-bottom: 1.5px solid var(--text-mute); border-right: 1.5px solid var(--text-mute); }
+  .card:hover::before, .card:hover::after { border-color: var(--purple); }
 
-      a:hover {
-        color: #a78bfa;
-      }
-    </style>
-    <script>
-      document.addEventListener("DOMContentLoaded", () => {
-        document.getElementById("server-url").textContent = SERVER_URL;
+  /* ---------- capability grid ---------- */
+  .cap-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+  @media (max-width: 900px) { .cap-grid { grid-template-columns: repeat(2, 1fr); } }
+  @media (max-width: 600px) { .cap-grid { grid-template-columns: 1fr; } }
+  .cap-card { padding: 26px 24px; transition: background .2s ease, border-color .2s ease; }
+  .cap-card:hover { background: var(--card-2); border-color: var(--border-soft); }
+  .cap-code {
+    display: inline-flex; align-items: center; font-family: var(--mono); font-size: 13px; font-weight: 600; letter-spacing: 0.08em;
+    color: var(--purple-2); margin-bottom: 18px;
+  }
+  .cap-code .b { color: var(--text-mute); font-weight: 400; }
+  .cap-card h3 { font-size: 18px; font-weight: 600; margin-bottom: 9px; }
+  .cap-card p { color: var(--text-dim); font-size: 14.5px; line-height: 1.6; }
+  .cap-card p code { color: var(--purple-2); font-family: var(--mono); font-size: 13px; }
 
-        const config = {
-          mcpServers: {
-            meridian: {
-              url: SERVER_URL,
-            },
-          },
-        };
-        document.getElementById("config-json").textContent = JSON.stringify(
-          config,
-          null,
-          2
-        );
+  /* ---------- quick start ---------- */
+  .qs-grid { display: grid; grid-template-columns: 1fr 1.2fr; gap: 18px; }
+  @media (max-width: 800px) { .qs-grid { grid-template-columns: 1fr; } }
+  .code-card { background: var(--card); border: 1px solid var(--border); overflow: hidden; }
+  .code-head { display: flex; align-items: center; justify-content: space-between; padding: 13px 18px; border-bottom: 1px solid var(--border-soft); background: rgba(13,19,32,0.55); }
+  .code-head .label { display: flex; align-items: center; gap: 10px; font-family: var(--mono); font-size: 13px; font-weight: 600; color: var(--text-dim); letter-spacing: 0.03em; }
+  .code-head .label .num { color: var(--purple-2); }
+  .copy-btn {
+    display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
+    font-family: var(--mono); font-size: 12px; font-weight: 600; color: var(--text-dim); letter-spacing: 0.04em;
+    background: transparent; border: 1px solid var(--border); border-radius: 999px; padding: 6px 13px; transition: all .16s ease;
+  }
+  .copy-btn:hover { color: var(--text); border-color: var(--purple); background: rgba(139,92,246,0.1); }
+  .copy-btn.copied { color: #34D399; border-color: rgba(52,211,153,0.5); background: rgba(52,211,153,0.1); }
+  pre { margin: 0; padding: 20px; overflow-x: auto; font-size: 13.5px; line-height: 1.7; color: #E5E7EB; background: var(--bg-2); }
+  pre code { color: inherit; background: none; padding: 0; font-size: inherit; }
+  .qs-hint { font-size: 13px; color: var(--text-mute); padding: 13px 18px 16px; line-height: 1.5; }
+  .qs-hint code { font-family: var(--mono); color: #93C5FD; }
 
-        const preBlocks = document.querySelectorAll("pre");
-        preBlocks.forEach((pre) => {
-          const button = document.createElement("button");
-          button.className = "copy-button";
-          button.textContent = "Copy";
-          button.onclick = () => {
-            const code = pre.querySelector("code")?.textContent || "";
-            navigator.clipboard.writeText(code).then(() => {
-              button.textContent = "Copied!";
-              button.classList.add("copied");
-              setTimeout(() => {
-                button.textContent = "Copy";
-                button.classList.remove("copied");
-              }, 2000);
-            });
-          };
-          pre.appendChild(button);
-        });
-      });
-    </script>
-  </head>
+  /* ---------- tables ---------- */
+  .table-wrap { border: 1px solid var(--border); background: var(--card); position: relative; }
+  .table-scroll { overflow-x: auto; }
+  table { width: 100%; border-collapse: collapse; min-width: 560px; }
+  thead th {
+    text-align: left; font-family: var(--mono); font-size: 11px; font-weight: 600;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-mute);
+    padding: 15px 22px; background: rgba(13,19,32,0.55); border-bottom: 1px solid var(--border);
+  }
+  tbody td { padding: 15px 22px; border-bottom: 1px solid var(--border-soft); font-size: 14.5px; color: var(--text-dim); vertical-align: middle; }
+  tbody tr:last-child td { border-bottom: none; }
+  tbody tr { transition: background .15s ease; }
+  tbody tr:hover { background: rgba(139,92,246,0.05); }
+  .role-name { font-family: var(--cond); font-weight: 600; color: var(--text); font-size: 16px; letter-spacing: 0.01em; }
+  .plus { color: var(--text-mute); font-style: italic; margin-right: 6px; font-size: 13px; }
+  .pill {
+    display: inline-flex; align-items: center; font-family: var(--mono); font-size: 12px; font-weight: 500;
+    color: #C7D2FE; background: rgba(99,102,241,0.12); border: 1px solid rgba(99,102,241,0.28);
+    border-radius: 6px; padding: 3px 9px; margin: 3px 4px 3px 0;
+  }
+  .pill.admin { color: #FBCFE8; background: rgba(236,72,153,0.12); border-color: rgba(236,72,153,0.32); }
+  .pill.any { color: var(--text-mute); background: rgba(107,114,128,0.12); border-color: var(--border); font-style: normal; }
+  .scope-cell { display: flex; flex-wrap: wrap; align-items: center; }
+  .tool-name { font-family: var(--mono); font-weight: 600; color: var(--text); font-size: 13.5px; }
+  .role-tag { display: inline-block; font-family: var(--mono); font-size: 10.5px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--pink); margin-left: 8px; vertical-align: middle; }
+  .table-note {
+    display: flex; align-items: flex-start; gap: 12px; font-size: 13.5px; color: var(--text-dim);
+    margin-bottom: 18px; padding: 13px 16px; border: 1px solid rgba(99,102,241,0.24); background: rgba(99,102,241,0.06);
+  }
+  .table-note .tag { font-family: var(--mono); font-size: 10.5px; font-weight: 700; letter-spacing: 0.1em; color: var(--indigo); border: 1px solid rgba(99,102,241,0.4); border-radius: 4px; padding: 2px 6px; flex-shrink: 0; margin-top: 1px; }
+  .table-note code { font-family: var(--mono); color: var(--purple-2); }
+  .table-note strong { color: var(--text); font-weight: 600; }
 
-  <body class="font-sans leading-relaxed flex flex-col min-h-screen">
-    <main class="container mx-auto px-4 pb-12 flex-grow pt-8">
-      <div class="max-w-4xl mx-auto">
-        <p class="text-sm uppercase tracking-widest text-primary font-semibold mb-2">
-          Meridian · Corporate Travel &amp; Expense
-        </p>
-        <h1 class="text-4xl font-bold font-heading text-white mb-6">
-          ✈️ Meridian MCP Server
-        </h1>
-        <p class="text-lg text-gray-300 mb-4">
-          Meridian is a (fictional) B2B travel &amp; expense platform — think
-          Navan or Ramp — exposed as a
-          <a href="https://modelcontextprotocol.com/" class="hover:text-primary"
-            >Model Context Protocol (MCP)</a
-          >
-          server so an AI agent can book trips, file expenses, approve reports,
-          and pull spend analytics on a user's behalf.
-        </p>
-        <p class="text-lg text-gray-300 mb-8">
-          It's a reference for
-          <strong class="text-white">Descope's B2B MCP auth</strong>: every
-          request is authenticated by
-          <a href="https://www.descope.com/" class="hover:text-primary"
-            >Descope</a
-          >, which stamps the caller's
-          <strong class="text-white">organization</strong> into the token so the
-          server can scope its own data to that tenant, and each tool is
-          authorized against the caller's
-          <strong class="text-white">role</strong>. Built with
-          <a href="https://gofastmcp.com/" class="hover:text-primary"
-            >FastMCP 3</a
-          >.
-        </p>
+  /* ---------- callout ---------- */
+  .callout { position: relative; padding: 42px; overflow: hidden; background: var(--card); border: 1px solid var(--border); }
+  .callout::before { content: ""; position: absolute; top: 0; left: 0; right: 0; height: 2px; background: linear-gradient(90deg, var(--purple), var(--pink)); }
+  .callout-grid { display: grid; grid-template-columns: 1.4fr 1fr; gap: 40px; align-items: center; }
+  @media (max-width: 780px) { .callout-grid { grid-template-columns: 1fr; gap: 26px; } .callout { padding: 30px; } }
+  .callout h2 { font-family: var(--cond); font-size: clamp(26px, 3vw, 34px); margin-bottom: 14px; }
+  .callout p { color: var(--text-dim); font-size: 15.5px; line-height: 1.64; margin-bottom: 12px; }
+  .callout p:last-child { margin-bottom: 0; }
+  .callout p strong { color: var(--text); font-weight: 600; }
+  .flow { display: flex; flex-direction: column; gap: 8px; background: var(--bg-2); border: 1px solid var(--border); padding: 22px; }
+  .flow-step { display: flex; align-items: center; gap: 13px; font-size: 13.5px; }
+  .flow-step .n { width: 26px; height: 26px; flex-shrink: 0; border: 1px solid var(--border); display: grid; place-items: center; font-family: var(--mono); font-size: 12px; font-weight: 600; color: var(--purple-2); }
+  .flow-step .t { color: var(--text-dim); }
+  .flow-step .t b { color: var(--text); font-weight: 600; }
+  .flow-arrow { padding-left: 12px; color: var(--text-mute); font-family: var(--mono); font-size: 13px; }
 
-        <h2 class="text-2xl font-bold font-heading text-white mt-8 mb-4">
-          Secured by Descope — B2B CIAM built for MCP
-        </h2>
-        <p class="text-gray-300 mb-4">
-          Meridian doesn't build auth. Descope is the authorization server in
-          front of the MCP endpoint, and it brings the full B2B identity stack
-          that agent-facing servers need:
-        </p>
-        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4 mb-10">
-          <div class="card rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-white mb-2">
-              🏢 Multi-tenant by design
-            </h3>
-            <p class="text-gray-300">
-              Descope adds the auth layer and stamps the caller's organization
-              into the token's <code class="px-1 rounded">dct</code> claim. Your
-              server reads it and scopes its own data — Descope never touches
-              your records; it just tells you which tenant the request is for.
-            </p>
+  /* ---------- endpoints ---------- */
+  .ep-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+  @media (max-width: 820px) { .ep-grid { grid-template-columns: 1fr; } }
+  .ep-card { padding: 22px; transition: border-color .2s ease, background .2s ease; }
+  .ep-card:hover { border-color: var(--border-soft); background: var(--card-2); }
+  .ep-method { display: inline-block; font-family: var(--mono); font-size: 11px; font-weight: 700; letter-spacing: 0.08em; padding: 3px 10px; border-radius: 4px; margin-bottom: 14px; }
+  .ep-method.post { color: #6EE7B7; background: rgba(16,185,129,0.12); border: 1px solid rgba(16,185,129,0.3); }
+  .ep-method.get { color: #93C5FD; background: rgba(59,130,246,0.12); border: 1px solid rgba(59,130,246,0.3); }
+  .ep-path { font-family: var(--mono); font-size: 13.5px; color: var(--text); word-break: break-all; margin-bottom: 10px; display: block; }
+  .ep-desc { font-size: 13.5px; color: var(--text-dim); line-height: 1.55; }
+
+  /* ---------- troubleshooting ---------- */
+  .ts-list { display: grid; gap: 14px; }
+  .ts-item { display: flex; gap: 18px; padding: 22px 24px; align-items: flex-start; }
+  .ts-num { flex-shrink: 0; font-family: var(--mono); font-size: 13px; font-weight: 600; color: var(--purple-2); letter-spacing: 0.06em; padding-top: 2px; }
+  .ts-body h4 { font-size: 16px; font-weight: 600; margin-bottom: 6px; }
+  .ts-body p { font-size: 14px; color: var(--text-dim); line-height: 1.55; }
+  .ts-body code { font-family: var(--mono); font-size: 12.5px; color: var(--purple-2); background: rgba(139,92,246,0.1); border: 1px solid rgba(139,92,246,0.22); border-radius: 5px; padding: 2px 7px; }
+
+  /* ---------- footer ---------- */
+  footer { border-top: 1px solid var(--border-soft); margin-top: 42px; padding: 48px 0 56px; background: var(--bg-2); position: relative; z-index: 1; }
+  .foot-grid { display: flex; align-items: center; justify-content: space-between; gap: 24px; flex-wrap: wrap; }
+  .foot-brand { display: flex; align-items: center; gap: 12px; }
+  .foot-links { display: flex; gap: 24px; flex-wrap: wrap; }
+  .foot-links a { font-family: var(--mono); font-size: 13px; font-weight: 500; color: var(--text-dim); letter-spacing: 0.02em; }
+  .foot-links a:hover { color: var(--purple-2); }
+  .foot-note { color: var(--text-mute); font-size: 13px; margin-top: 24px; line-height: 1.55; }
+
+  .fade-up { opacity: 0; transform: translateY(18px); transition: opacity .55s ease, transform .55s ease; }
+  .fade-up.in { opacity: 1; transform: none; }
+  @media (prefers-reduced-motion: reduce) { .fade-up { opacity: 1; transform: none; transition: none; } html { scroll-behavior: auto; } }
+</style>
+</head>
+<body>
+
+<div class="bg-fx">
+  <div class="halo"></div>
+  <div class="grid-lines"></div>
+  <div class="meridian"></div>
+</div>
+
+<nav>
+  <div class="wrap">
+    <div class="brand">
+      <span class="mark">
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M21 16v-2l-8-5V3.5a1.5 1.5 0 0 0-3 0V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5L21 16Z" fill="#A78BFA"></path></svg>
+      </span>
+      <span>Meridian</span>
+    </div>
+    <div class="nav-links">
+      <a href="#secured">Security</a>
+      <a href="#quickstart">Quick start</a>
+      <a href="#tools">Tools</a>
+      <a href="#endpoints">API</a>
+      <a class="nav-badge" href="#quickstart"><span class="dot"></span> MCP&nbsp;·&nbsp;live</a>
+    </div>
+  </div>
+</nav>
+
+<main>
+  <!-- HERO -->
+  <header class="hero">
+    <div class="wrap">
+      <span class="eyebrow"><span class="code">MER</span> Corporate travel &amp; expense</span>
+      <h1>The Meridian <span class="accent">MCP&nbsp;Server</span> for travel &amp; expense agents</h1>
+      <p class="lede">A <strong>Model Context Protocol</strong> server that lets an AI agent book trips, file expenses, approve reports, and pull spend analytics — securely, on a user's behalf.</p>
+      <p class="hero-sub">It's a reference for <span class="hl">Descope's B2B MCP auth</span>: every request is authenticated by Descope, which stamps the caller's organization into the token so the server can scope its own data to that tenant — and each tool is authorized against the caller's role.</p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="#quickstart">Connect a client
+          <svg class="arw" width="15" height="15" viewBox="0 0 24 24" fill="none"><path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+        </a>
+        <a class="btn btn-ghost" href="#secured">How auth works</a>
+      </div>
+      <div class="meta-row">
+        <span class="meta-chip"><span class="tick">›</span> Built with <b>FastMCP&nbsp;3</b></span>
+        <span class="meta-chip demo">Meridian is a fictional company, for demo purposes</span>
+      </div>
+    </div>
+  </header>
+
+  <!-- SECURED BY DESCOPE -->
+  <section class="block" id="secured">
+    <div class="wrap">
+      <div class="sec-head center fade-up">
+        <span class="overline"><span class="idx">01</span><span class="rule"></span> Secured by Descope</span>
+        <h2>B2B CIAM built for MCP</h2>
+        <p>Meridian doesn't build auth. <strong style="color:var(--text)">Descope is the authorization server</strong> sitting in front of the MCP endpoint — handling identity, tenancy, and tool-level authorization so the server can focus on travel and expense.</p>
+      </div>
+      <div class="cap-grid">
+        <article class="card cap-card fade-up">
+          <span class="cap-code"><span class="b">//&nbsp;</span>MT</span>
+          <h3>Multi-tenant by design</h3>
+          <p>Descope adds the auth layer and stamps the caller's org into the token's <code>dct</code> claim. The server reads it and scopes its own data — Descope never touches your records; it just tells you which tenant the request is for.</p>
+        </article>
+        <article class="card cap-card fade-up">
+          <span class="cap-code"><span class="b">//&nbsp;</span>RBAC</span>
+          <h3>Role-based tool access</h3>
+          <p>Each tool declares the OAuth scope it needs; callers only see the tools their role allows — enforced on every request, not just at login.</p>
+        </article>
+        <article class="card cap-card fade-up">
+          <span class="cap-code"><span class="b">//&nbsp;</span>SSO</span>
+          <h3>Enterprise SSO &amp; group mapping</h3>
+          <p>Connect the customer's Okta / Entra ID / any OIDC-SAML IdP. Descope maps IdP groups → roles, scopes, and permissions, with tenant-level policies controlling tool access. No code changes to add a customer.</p>
+        </article>
+        <article class="card cap-card fade-up">
+          <span class="cap-code"><span class="b">//&nbsp;</span>JAG</span>
+          <h3>ID-JAG / Cross-App Access</h3>
+          <p>Clients like Claude and VS Code sign in instantly via an enterprise-issued assertion — no separate SSO login or consent screen. IT authorizes the app once at the IdP; users get Meridian pre-connected.</p>
+        </article>
+        <article class="card cap-card fade-up">
+          <span class="cap-code"><span class="b">//&nbsp;</span>DCR</span>
+          <h3>CIMD &amp; Dynamic Client Registration</h3>
+          <p>MCP clients self-onboard via CIMD / DCR — no hand-provisioned secrets. Registration flows can tag, classify, and verify clients as they come online.</p>
+        </article>
+        <article class="card cap-card fade-up">
+          <span class="cap-code"><span class="b">//&nbsp;</span>BYO</span>
+          <h3>Bring your own auth</h3>
+          <p>Plug in an existing auth system as an external provider — no rip-and-replace. Descope becomes the OAuth 2.1 authorization server for the MCP endpoint while your identity source stays the source of truth.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- QUICK START -->
+  <section class="block" id="quickstart">
+    <div class="wrap">
+      <div class="sec-head fade-up">
+        <span class="overline"><span class="idx">02</span><span class="rule"></span> Quick start</span>
+        <h2>Point your MCP client at Meridian</h2>
+        <p>Add the server URL to your MCP client config. On first connect you'll be sent through Descope's OAuth flow; the issued token carries your org and scopes.</p>
+      </div>
+      <div class="qs-grid">
+        <div class="code-card fade-up">
+          <div class="code-head">
+            <span class="label"><span class="num">01</span> server_url</span>
+            <button class="copy-btn" type="button">Copy</button>
           </div>
-          <div class="card rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-white mb-2">
-              🔐 Role-based tool access
-            </h3>
-            <p class="text-gray-300">
-              Each tool declares the OAuth scope it needs, so callers only ever
-              see the tools their role allows — enforced at the transport layer
-              on every request.
-            </p>
-          </div>
-          <div class="card rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-white mb-2">
-              🪪 Enterprise SSO &amp; group mapping
-            </h3>
-            <p class="text-gray-300">
-              Connect the customer's Okta, Entra ID, or any OIDC/SAML IdP. Descope
-              maps IdP <strong class="text-white">groups → roles, scopes, and
-              permissions</strong>, and tenant-level policies control tool access
-              per organization — no code changes to add a new customer.
-            </p>
-          </div>
-          <div class="card rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-white mb-2">
-              ⚡ ID-JAG / Cross-App Access
-            </h3>
-            <p class="text-gray-300">
-              Clients like <strong class="text-white">Claude</strong> and
-              <strong class="text-white">VS Code</strong> sign in instantly using
-              an enterprise-issued assertion — <strong class="text-white">no
-              separate SSO login or consent screen</strong>. IT authorizes the app
-              once at the IdP; users get Meridian pre-connected.
-            </p>
-          </div>
-          <div class="card rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-white mb-2">
-              🤝 CIMD &amp; Dynamic Client Registration
-            </h3>
-            <p class="text-gray-300">
-              MCP clients self-onboard via CIMD / DCR — no hand-provisioned client
-              secrets. Client Registration Flows let you
-              <strong class="text-white">tag, classify, and verify</strong> each
-              client before it's trusted.
-            </p>
-          </div>
-          <div class="card rounded-lg p-6">
-            <h3 class="text-lg font-semibold text-white mb-2">
-              🧩 Bring your own auth
-            </h3>
-            <p class="text-gray-300">
-              Already have an auth system? Plug it in as an external
-              provider — no rip-and-replace. Descope becomes the OAuth 2.1
-              authorization server for your MCP endpoint while your existing
-              identity source stays the source of truth.
-            </p>
-          </div>
+          <pre><code id="server-url">loading…</code></pre>
+          <p class="qs-hint">Requires a <code>Bearer</code> token. Your client obtains it automatically via OAuth on first use.</p>
         </div>
-
-        <h2 class="text-2xl font-bold font-heading text-white mt-8 mb-4">
-          Quick Start
-        </h2>
-        <div class="card rounded-lg p-6 mb-6">
-          <h3 class="text-xl font-semibold text-white mb-3">Server URL</h3>
-          <pre><code class="px-2 py-1 rounded" id="server-url"></code></pre>
-        </div>
-
-        <div class="card rounded-lg p-6 mb-6">
-          <h3 class="text-xl font-semibold text-white mb-3">Configuration</h3>
-          <pre><code id="config-json"></code></pre>
-        </div>
-
-        <h2 class="text-2xl font-bold font-heading text-white mt-8 mb-4">
-          Roles &amp; Scopes
-        </h2>
-        <div class="card rounded-lg p-6 mb-6">
-          <p class="text-gray-300 mb-4">
-            Roles are bundles of scopes. Connect with a token whose scopes match
-            a role, and only that role's tools appear.
-          </p>
-          <div class="overflow-x-auto">
-            <table class="w-full text-left text-gray-300">
-              <thead>
-                <tr class="border-b border-gray-700 text-white">
-                  <th class="py-2 pr-4 font-semibold">Role</th>
-                  <th class="py-2 font-semibold">Scopes</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-gray-800">
-                <tr>
-                  <td class="py-3 pr-4"><span class="role-chip">Employee</span></td>
-                  <td class="py-3">
-                    <span class="scope-badge">expenses:read</span>
-                    <span class="scope-badge">expenses:write</span>
-                    <span class="scope-badge">trips:read</span>
-                    <span class="scope-badge">trips:book</span>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="py-3 pr-4"><span class="role-chip">Manager</span></td>
-                  <td class="py-3">
-                    <span class="text-gray-500">Employee +</span>
-                    <span class="scope-badge">expenses:approve</span>
-                    <span class="scope-badge">reports:read</span>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="py-3 pr-4">
-                    <span class="role-chip">Finance Admin</span>
-                  </td>
-                  <td class="py-3">
-                    <span class="text-gray-500">Manager +</span>
-                    <span class="scope-badge">admin</span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+        <div class="code-card fade-up">
+          <div class="code-head">
+            <span class="label"><span class="num">02</span> config.json</span>
+            <button class="copy-btn" type="button">Copy</button>
           </div>
+          <pre><code id="config-json">loading…</code></pre>
         </div>
+      </div>
+    </div>
+  </section>
 
-        <h2 class="text-2xl font-bold font-heading text-white mt-8 mb-4">
-          Tools &amp; Required Scopes
-        </h2>
-        <div class="card rounded-lg p-6 mb-6">
-          <p class="text-gray-300 mb-4">
-            Tools whose scope you don't hold are hidden from
-            <code class="px-1 rounded">tools/list</code> — clients only ever see
-            what their token allows.
-          </p>
-          <div class="overflow-x-auto">
-            <table class="w-full text-left text-gray-300">
-              <thead>
-                <tr class="border-b border-gray-700 text-white">
-                  <th class="py-2 pr-4 font-semibold">Tool</th>
-                  <th class="py-2 pr-4 font-semibold">Required scope</th>
-                  <th class="py-2 font-semibold">Description</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-gray-800">
-                <tr>
-                  <td class="py-2 pr-4"><code>whoami</code></td>
-                  <td class="py-2 pr-4"><span class="text-gray-500">any authed</span></td>
-                  <td class="py-2">Identity, organization, and granted scopes</td>
-                </tr>
-                <tr>
-                  <td class="py-2 pr-4"><code>list_expenses</code></td>
-                  <td class="py-2 pr-4"><span class="scope-badge">expenses:read</span></td>
-                  <td class="py-2">List your org's expenses</td>
-                </tr>
-                <tr>
-                  <td class="py-2 pr-4"><code>get_expense</code></td>
-                  <td class="py-2 pr-4"><span class="scope-badge">expenses:read</span></td>
-                  <td class="py-2">Fetch one expense by id</td>
-                </tr>
-                <tr>
-                  <td class="py-2 pr-4"><code>submit_expense</code></td>
-                  <td class="py-2 pr-4"><span class="scope-badge">expenses:write</span></td>
-                  <td class="py-2">File a new expense report</td>
-                </tr>
-                <tr>
-                  <td class="py-2 pr-4"><code>approve_expense</code></td>
-                  <td class="py-2 pr-4"><span class="scope-badge">expenses:approve</span></td>
-                  <td class="py-2">Approve a pending expense (Manager)</td>
-                </tr>
-                <tr>
-                  <td class="py-2 pr-4"><code>reject_expense</code></td>
-                  <td class="py-2 pr-4"><span class="scope-badge">expenses:approve</span></td>
-                  <td class="py-2">Reject a pending expense (Manager)</td>
-                </tr>
-                <tr>
-                  <td class="py-2 pr-4"><code>search_flights</code></td>
-                  <td class="py-2 pr-4"><span class="scope-badge">trips:read</span></td>
-                  <td class="py-2">Search in-policy flights</td>
-                </tr>
-                <tr>
-                  <td class="py-2 pr-4"><code>list_trips</code></td>
-                  <td class="py-2 pr-4"><span class="scope-badge">trips:read</span></td>
-                  <td class="py-2">List booked trips</td>
-                </tr>
-                <tr>
-                  <td class="py-2 pr-4"><code>book_trip</code></td>
-                  <td class="py-2 pr-4"><span class="scope-badge">trips:book</span></td>
-                  <td class="py-2">Book a trip (enforced against policy)</td>
-                </tr>
-                <tr>
-                  <td class="py-2 pr-4"><code>expense_summary</code></td>
-                  <td class="py-2 pr-4"><span class="scope-badge">reports:read</span></td>
-                  <td class="py-2">Spend analytics &amp; budget usage (Manager)</td>
-                </tr>
-                <tr>
-                  <td class="py-2 pr-4"><code>list_employees</code></td>
-                  <td class="py-2 pr-4"><span class="scope-badge">admin</span></td>
-                  <td class="py-2">Organization directory (Finance Admin)</td>
-                </tr>
-                <tr>
-                  <td class="py-2 pr-4"><code>set_travel_policy</code></td>
-                  <td class="py-2 pr-4"><span class="scope-badge">admin</span></td>
-                  <td class="py-2">Update the org's travel/expense policy</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+  <!-- ROLES & SCOPES -->
+  <section class="block" id="roles">
+    <div class="wrap">
+      <div class="sec-head fade-up">
+        <span class="overline"><span class="idx">03</span><span class="rule"></span> Access model</span>
+        <h2>Roles &amp; scopes</h2>
+        <p>Roles are cumulative. Descope maps each caller's role to a set of OAuth scopes; those scopes gate which tools appear and run.</p>
+      </div>
+      <div class="table-wrap fade-up">
+        <div class="table-scroll">
+          <table>
+            <thead><tr><th style="width:200px">Role</th><th>Granted scopes</th></tr></thead>
+            <tbody>
+              <tr>
+                <td><span class="role-name">Employee</span></td>
+                <td><div class="scope-cell">
+                  <span class="pill">expenses:read</span><span class="pill">expenses:write</span><span class="pill">trips:read</span><span class="pill">trips:book</span>
+                </div></td>
+              </tr>
+              <tr>
+                <td><span class="role-name">Manager</span></td>
+                <td><div class="scope-cell">
+                  <span class="plus">Employee +</span><span class="pill">expenses:approve</span><span class="pill">reports:read</span>
+                </div></td>
+              </tr>
+              <tr>
+                <td><span class="role-name">Finance Admin</span></td>
+                <td><div class="scope-cell">
+                  <span class="plus">Manager +</span><span class="pill admin">admin</span>
+                </div></td>
+              </tr>
+            </tbody>
+          </table>
         </div>
+      </div>
+    </div>
+  </section>
 
-        <h2 class="text-2xl font-bold font-heading text-white mt-8 mb-4">
-          API Endpoints
-        </h2>
-        <div class="card rounded-lg p-6 mb-6">
-          <div class="mb-4">
-            <h3 class="text-lg font-semibold text-white mb-2">MCP Server</h3>
-            <code class="bg-gray-800 px-2 py-1 rounded">POST /mcp</code>
-            <p class="mt-1 text-gray-300">
-              The main MCP endpoint (requires a Bearer token)
-            </p>
-          </div>
-          <div class="mb-4">
-            <h3 class="text-lg font-semibold text-white mb-2">OAuth Metadata</h3>
-            <code class="bg-gray-800 px-2 py-1 rounded"
-              >GET /.well-known/oauth-protected-resource/mcp</code
-            >
-            <p class="mt-1 text-gray-300">
-              Resource metadata for the MCP endpoint
-            </p>
-          </div>
+  <!-- TOOLS -->
+  <section class="block" id="tools">
+    <div class="wrap">
+      <div class="sec-head fade-up">
+        <span class="overline"><span class="idx">04</span><span class="rule"></span> Capabilities</span>
+        <h2>Tools &amp; required scopes</h2>
+      </div>
+      <div class="table-note fade-up">
+        <span class="tag">NOTE</span>
+        <span>Tools whose scope you don't hold are <strong>hidden from <code>tools/list</code></strong> — clients only ever see what their token allows.</span>
+      </div>
+      <div class="table-wrap fade-up">
+        <div class="table-scroll">
+          <table>
+            <thead><tr><th style="width:210px">Tool</th><th style="width:190px">Required scope</th><th>Description</th></tr></thead>
+            <tbody>
+              <tr><td><span class="tool-name">whoami</span></td><td><span class="pill any">any authenticated</span></td><td>Identity, organization, and granted scopes</td></tr>
+              <tr><td><span class="tool-name">list_expenses</span></td><td><span class="pill">expenses:read</span></td><td>List your org's expenses</td></tr>
+              <tr><td><span class="tool-name">get_expense</span></td><td><span class="pill">expenses:read</span></td><td>Fetch one expense by id</td></tr>
+              <tr><td><span class="tool-name">submit_expense</span></td><td><span class="pill">expenses:write</span></td><td>File a new expense report</td></tr>
+              <tr><td><span class="tool-name">approve_expense</span></td><td><span class="pill">expenses:approve</span></td><td>Approve a pending expense <span class="role-tag">Manager</span></td></tr>
+              <tr><td><span class="tool-name">reject_expense</span></td><td><span class="pill">expenses:approve</span></td><td>Reject a pending expense <span class="role-tag">Manager</span></td></tr>
+              <tr><td><span class="tool-name">search_flights</span></td><td><span class="pill">trips:read</span></td><td>Search in-policy flights</td></tr>
+              <tr><td><span class="tool-name">list_trips</span></td><td><span class="pill">trips:read</span></td><td>List booked trips</td></tr>
+              <tr><td><span class="tool-name">book_trip</span></td><td><span class="pill">trips:book</span></td><td>Book a trip (enforced against policy)</td></tr>
+              <tr><td><span class="tool-name">expense_summary</span></td><td><span class="pill">reports:read</span></td><td>Spend analytics &amp; budget usage <span class="role-tag">Manager</span></td></tr>
+              <tr><td><span class="tool-name">list_employees</span></td><td><span class="pill admin">admin</span></td><td>Organization directory <span class="role-tag">Finance Admin</span></td></tr>
+              <tr><td><span class="tool-name">set_travel_policy</span></td><td><span class="pill admin">admin</span></td><td>Update the org's travel/expense policy</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ID-JAG CALLOUT -->
+  <section class="block" id="idjag">
+    <div class="wrap">
+      <div class="callout fade-up">
+        <div class="callout-grid">
           <div>
-            <h3 class="text-lg font-semibold text-white mb-2">
-              Authorization Server Metadata
-            </h3>
-            <code class="bg-gray-800 px-2 py-1 rounded"
-              >GET /.well-known/oauth-authorization-server</code
-            >
-            <p class="mt-1 text-gray-300">
-              OAuth 2.1 authorization server metadata (from Descope)
-            </p>
+            <span class="overline"><span class="idx">05</span><span class="rule"></span> Enterprise access</span>
+            <h2>ID-JAG &amp; Cross-App Access</h2>
+            <p>For workforce deployments — Claude used internally across a company — the enterprise IdP issues a short-lived <strong>ID-JAG assertion</strong> that Descope exchanges for a Meridian access token. No separate consent screen, no second login.</p>
+            <p>Enabled per tenant in Descope, it <strong>complements — not replaces</strong> — the interactive OAuth&nbsp;+&nbsp;DCR flow used by individual clients.</p>
+          </div>
+          <div class="flow">
+            <div class="flow-step"><span class="n">1</span><span class="t">Enterprise <b>IdP</b> issues ID-JAG assertion</span></div>
+            <div class="flow-arrow">↓</div>
+            <div class="flow-step"><span class="n">2</span><span class="t"><b>Descope</b> exchanges it for an access token</span></div>
+            <div class="flow-arrow">↓</div>
+            <div class="flow-step"><span class="n">3</span><span class="t"><b>Meridian</b> serves tenant-scoped data</span></div>
           </div>
         </div>
+      </div>
+    </div>
+  </section>
 
-        <h2 class="text-2xl font-bold font-heading text-white mt-8 mb-4">
-          Troubleshooting
-        </h2>
-        <div class="card rounded-lg p-6 mb-6">
-          <p class="mb-4 text-gray-300">
-            If you encounter authentication issues, try clearing the cached
-            authentication files:
-          </p>
-          <pre><code>rm -rf ~/.mcp-auth</code></pre>
-          <p class="mt-4 text-gray-300">
-            If a tool you expect is missing, confirm the scope is granted on your
-            token (decode your access token to inspect its scopes) and that the
-            scope is defined on your Descope MCP Server. If
-            <code class="px-1 rounded">whoami</code> shows the default org, your
-            token isn't carrying a tenant claim yet.
-          </p>
+  <!-- ENDPOINTS -->
+  <section class="block" id="endpoints">
+    <div class="wrap">
+      <div class="sec-head fade-up">
+        <span class="overline"><span class="idx">06</span><span class="rule"></span> Reference</span>
+        <h2>API endpoints</h2>
+      </div>
+      <div class="ep-grid">
+        <div class="card ep-card fade-up">
+          <span class="ep-method post">POST</span>
+          <code class="ep-path">/mcp</code>
+          <p class="ep-desc">Main MCP endpoint. Requires a valid Bearer token.</p>
+        </div>
+        <div class="card ep-card fade-up">
+          <span class="ep-method get">GET</span>
+          <code class="ep-path">/.well-known/oauth-protected-resource/mcp</code>
+          <p class="ep-desc">Protected-resource metadata for the MCP endpoint.</p>
+        </div>
+        <div class="card ep-card fade-up">
+          <span class="ep-method get">GET</span>
+          <code class="ep-path">/.well-known/oauth-authorization-server</code>
+          <p class="ep-desc">OAuth 2.1 authorization-server metadata, served from Descope.</p>
         </div>
       </div>
-    </main>
-    <footer class="bg-gray-900 py-6 mt-12">
-      <div class="container mx-auto px-4 text-center text-gray-400">
-        <p>
-          Meridian is a fictional company for demo purposes. Built with FastMCP 3
-          and Descope.
-        </p>
+    </div>
+  </section>
+
+  <!-- TROUBLESHOOTING -->
+  <section class="block" id="troubleshooting">
+    <div class="wrap">
+      <div class="sec-head fade-up">
+        <span class="overline"><span class="idx">07</span><span class="rule"></span> Help</span>
+        <h2>Troubleshooting</h2>
       </div>
-    </footer>
-  </body>
-</html>
+      <div class="ts-list">
+        <div class="card ts-item fade-up">
+          <span class="ts-num">01</span>
+          <div class="ts-body">
+            <h4>Clear cached auth</h4>
+            <p>Stale credentials causing 401s? Remove the local auth cache and reconnect: <code>rm -rf ~/.mcp-auth</code></p>
+          </div>
+        </div>
+        <div class="card ts-item fade-up">
+          <span class="ts-num">02</span>
+          <div class="ts-body">
+            <h4>A tool is missing</h4>
+            <p>If a tool doesn't appear in <code>tools/list</code>, your token lacks its required scope. Check your role in the access model above.</p>
+          </div>
+        </div>
+        <div class="card ts-item fade-up">
+          <span class="ts-num">03</span>
+          <div class="ts-body">
+            <h4>whoami shows the default org</h4>
+            <p>If <code>whoami</code> returns the default organization, your token isn't carrying a tenant claim yet — re-authenticate through your enterprise tenant.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer>
+  <div class="wrap">
+    <div class="foot-grid">
+      <div class="foot-brand">
+        <span class="mark" style="width:32px;height:32px;border:1px solid var(--border);border-radius:8px;display:grid;place-items:center;background:var(--card);">
+          <svg viewBox="0 0 24 24" width="19" height="19" fill="none"><path d="M21 16v-2l-8-5V3.5a1.5 1.5 0 0 0-3 0V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5L21 16Z" fill="#A78BFA"></path></svg>
+        </span>
+        <span style="font-family:var(--cond);font-weight:600;font-size:19px;">Meridian</span>
+      </div>
+      <div class="foot-links">
+        <a href="https://descope.com" target="_blank" rel="noopener">Descope →</a>
+        <a href="https://modelcontextprotocol.com" target="_blank" rel="noopener">MCP →</a>
+        <a href="https://gofastmcp.com" target="_blank" rel="noopener">FastMCP →</a>
+      </div>
+    </div>
+    <p class="foot-note">Meridian is a fictional company for demo purposes. Built with FastMCP&nbsp;3 and Descope.</p>
+  </div>
+</footer>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    // --- dynamic server URL + config JSON ---
+    var origin = window.location.origin;
+    var serverUrl = origin + "/mcp";
+
+    var urlEl = document.getElementById("server-url");
+    if (urlEl) urlEl.textContent = serverUrl;
+
+    var configObj = { mcpServers: { meridian: { url: serverUrl } } };
+    var configEl = document.getElementById("config-json");
+    if (configEl) configEl.textContent = JSON.stringify(configObj, null, 2);
+
+    // --- copy buttons on every <pre> block ---
+    document.querySelectorAll("pre").forEach(function (pre) {
+      var card = pre.closest(".code-card");
+      var btn = card ? card.querySelector(".copy-btn") : null;
+      if (!btn) return;
+      var original = btn.textContent;
+      btn.addEventListener("click", function () {
+        var text = pre.innerText;
+        var done = function () {
+          btn.classList.add("copied");
+          btn.textContent = "Copied!";
+          setTimeout(function () {
+            btn.classList.remove("copied");
+            btn.textContent = original;
+          }, 1600);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(done, function () { fallbackCopy(text); done(); });
+        } else {
+          fallbackCopy(text); done();
+        }
+      });
+    });
+
+    function fallbackCopy(text) {
+      var ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      try { document.execCommand("copy"); } catch (e) {}
+      document.body.removeChild(ta);
+    }
+
+    // --- scroll reveal ---
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) { e.target.classList.add("in"); io.unobserve(e.target); }
+      });
+    }, { threshold: 0.12, rootMargin: "0px 0px -40px 0px" });
+    document.querySelectorAll(".fade-up").forEach(function (el, i) {
+      el.style.transitionDelay = (Math.min(i % 6, 5) * 0.05) + "s";
+      io.observe(el);
+    });
+  });
+</script>
+
+</body></html>

--- a/examples/b2b-mcp-server/index.html
+++ b/examples/b2b-mcp-server/index.html
@@ -3,6 +3,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian MCP Server · Corporate Travel &amp; Expense</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20width%3D%2264%22%20height%3D%2264%22%20viewBox%3D%220%200%2064%2064%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20role%3D%22img%22%20aria-label%3D%22Meridian%22%3E%20%3Ctitle%3EMeridian%3C%2Ftitle%3E%20%3Cdefs%3E%20%3ClinearGradient%20id%3D%22fg%22%20x1%3D%2216%22%20y1%3D%2214%22%20x2%3D%2250%22%20y2%3D%2252%22%20gradientUnits%3D%22userSpaceOnUse%22%3E%20%3Cstop%20stop-color%3D%22%23A78BFA%22%2F%3E%20%3Cstop%20offset%3D%220.55%22%20stop-color%3D%22%238B5CF6%22%2F%3E%20%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23EC4899%22%2F%3E%20%3C%2FlinearGradient%3E%20%3C%2Fdefs%3E%20%3Crect%20width%3D%2264%22%20height%3D%2264%22%20rx%3D%2215%22%20fill%3D%22%23111827%22%2F%3E%20%3Crect%20x%3D%220.5%22%20y%3D%220.5%22%20width%3D%2263%22%20height%3D%2263%22%20rx%3D%2214.5%22%20stroke%3D%22%23374151%22%2F%3E%20%3Cpath%20d%3D%22M16%2033%20H48%22%20stroke%3D%22url%28%23fg%29%22%20stroke-width%3D%222.6%22%20stroke-linecap%3D%22round%22%20opacity%3D%220.55%22%2F%3E%20%3Cellipse%20cx%3D%2232%22%20cy%3D%2233%22%20rx%3D%227%22%20ry%3D%2216%22%20stroke%3D%22url%28%23fg%29%22%20stroke-width%3D%222.6%22%2F%3E%20%3Ccircle%20cx%3D%2232%22%20cy%3D%2233%22%20r%3D%2216%22%20stroke%3D%22url%28%23fg%29%22%20stroke-width%3D%223.2%22%2F%3E%20%3Crect%20x%3D%2227.8%22%20y%3D%2212.8%22%20width%3D%228.4%22%20height%3D%228.4%22%20rx%3D%221.5%22%20transform%3D%22rotate%2845%2032%2017%29%22%20fill%3D%22%23EC4899%22%2F%3E%20%3C%2Fsvg%3E">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Barlow:wght@300;400;500;600;700&family=Barlow+Semi+Condensed:wght@500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap">
@@ -289,7 +290,7 @@
   <div class="wrap">
     <div class="brand">
       <span class="mark">
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M21 16v-2l-8-5V3.5a1.5 1.5 0 0 0-3 0V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5L21 16Z" fill="#A78BFA"></path></svg>
+        <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="navmg" x1="12" y1="10" x2="54" y2="56" gradientUnits="userSpaceOnUse"><stop stop-color="#8B5CF6"></stop><stop offset="0.55" stop-color="#6366F1"></stop><stop offset="1" stop-color="#EC4899"></stop></linearGradient></defs><path d="M12.5 34 H51.5" stroke="url(#navmg)" stroke-width="2.4" stroke-linecap="round" opacity="0.5"></path><ellipse cx="32" cy="34" rx="8" ry="20" stroke="url(#navmg)" stroke-width="2.4"></ellipse><circle cx="32" cy="34" r="20" stroke="url(#navmg)" stroke-width="3"></circle><rect x="27.4" y="9.4" width="9.2" height="9.2" rx="1.6" transform="rotate(45 32 14)" fill="#EC4899"></rect></svg>
       </span>
       <span>Meridian</span>
     </div>
@@ -557,7 +558,7 @@
     <div class="foot-grid">
       <div class="foot-brand">
         <span class="mark" style="width:32px;height:32px;border:1px solid var(--border);border-radius:8px;display:grid;place-items:center;background:var(--card);">
-          <svg viewBox="0 0 24 24" width="19" height="19" fill="none"><path d="M21 16v-2l-8-5V3.5a1.5 1.5 0 0 0-3 0V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5L21 16Z" fill="#A78BFA"></path></svg>
+          <svg viewBox="0 0 64 64" width="19" height="19" fill="none"><defs><linearGradient id="footmg" x1="12" y1="10" x2="54" y2="56" gradientUnits="userSpaceOnUse"><stop stop-color="#8B5CF6"></stop><stop offset="0.55" stop-color="#6366F1"></stop><stop offset="1" stop-color="#EC4899"></stop></linearGradient></defs><path d="M12.5 34 H51.5" stroke="url(#footmg)" stroke-width="2.4" stroke-linecap="round" opacity="0.5"></path><ellipse cx="32" cy="34" rx="8" ry="20" stroke="url(#footmg)" stroke-width="2.4"></ellipse><circle cx="32" cy="34" r="20" stroke="url(#footmg)" stroke-width="3"></circle><rect x="27.4" y="9.4" width="9.2" height="9.2" rx="1.6" transform="rotate(45 32 14)" fill="#EC4899"></rect></svg>
         </span>
         <span style="font-family:var(--cond);font-weight:600;font-size:19px;">Meridian</span>
       </div>

--- a/examples/b2b-mcp-server/index.html
+++ b/examples/b2b-mcp-server/index.html
@@ -193,9 +193,10 @@
           request is authenticated by
           <a href="https://www.descope.com/" class="hover:text-primary"
             >Descope</a
-          >, scoped to the caller's
-          <strong class="text-white">organization</strong> (tenant), and each
-          tool is authorized against the caller's
+          >, which stamps the caller's
+          <strong class="text-white">organization</strong> into the token so the
+          server can scope its own data to that tenant, and each tool is
+          authorized against the caller's
           <strong class="text-white">role</strong>. Built with
           <a href="https://gofastmcp.com/" class="hover:text-primary"
             >FastMCP 3</a
@@ -216,9 +217,10 @@
               🏢 Multi-tenant by design
             </h3>
             <p class="text-gray-300">
-              Tokens carry the caller's organization. Every tool reads and writes
-              only that tenant's data — Acme's agent never sees Globex's
-              expenses, even on the same server.
+              Descope adds the auth layer and stamps the caller's organization
+              into the token's <code class="px-1 rounded">dct</code> claim. Your
+              server reads it and scopes its own data — Descope never touches
+              your records; it just tells you which tenant the request is for.
             </p>
           </div>
           <div class="card rounded-lg p-6">

--- a/examples/b2b-mcp-server/index.html
+++ b/examples/b2b-mcp-server/index.html
@@ -1,0 +1,487 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Meridian — Travel &amp; Expense MCP Server</title>
+    <script>
+      const SERVER_URL = window.location.origin + "/mcp";
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              primary: "#8B5CF6", // Purple
+              secondary: "#6366F1", // Indigo
+              accent: "#EC4899", // Pink
+              dark: {
+                DEFAULT: "#111827",
+                lighter: "#1F2937",
+              },
+            },
+            fontFamily: {
+              sans: ["Inter", "system-ui", "sans-serif"],
+              heading: ["Space Grotesk", "system-ui", "sans-serif"],
+            },
+          },
+        },
+      };
+    </script>
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap");
+
+      body {
+        background-color: #111827;
+        color: #f3f4f6;
+      }
+
+      pre {
+        background: #1f2937 !important;
+        color: #e5e7eb !important;
+        position: relative;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        word-break: break-word;
+        border-radius: 0.5rem;
+        padding: 0.7rem;
+        border: 1px solid #374151;
+        text-shadow: none;
+        -webkit-text-fill-color: #e5e7eb;
+      }
+
+      pre code {
+        background: transparent !important;
+        color: inherit !important;
+        text-shadow: none;
+        -webkit-text-fill-color: inherit;
+      }
+
+      pre .copy-button {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        padding: 0.25rem 0.5rem;
+        background: rgba(139, 92, 246, 0.1);
+        border: 1px solid rgba(139, 92, 246, 0.2);
+        color: #8b5cf6;
+        border-radius: 0.25rem;
+        cursor: pointer;
+        font-size: 0.75rem;
+        transition: all 0.2s;
+      }
+
+      pre .copy-button:hover {
+        background: rgba(139, 92, 246, 0.2);
+      }
+
+      pre .copy-button.copied {
+        background: rgba(139, 92, 246, 0.2);
+        border-color: rgba(139, 92, 246, 0.2);
+      }
+
+      .card {
+        background: #1f2937;
+        border: 1px solid #374151;
+        transition: all 0.2s;
+      }
+
+      .card:hover {
+        border-color: #8b5cf6;
+      }
+
+      code {
+        background: #374151;
+        color: #e5e7eb;
+      }
+
+      .scope-badge {
+        display: inline-block;
+        font-size: 0.7rem;
+        font-weight: 600;
+        padding: 0.1rem 0.5rem;
+        border-radius: 9999px;
+        border: 1px solid rgba(139, 92, 246, 0.4);
+        background: rgba(139, 92, 246, 0.12);
+        color: #c4b5fd;
+        font-family: ui-monospace, monospace;
+      }
+
+      .role-chip {
+        display: inline-block;
+        font-size: 0.75rem;
+        font-weight: 600;
+        padding: 0.15rem 0.6rem;
+        border-radius: 9999px;
+        border: 1px solid #374151;
+        background: #111827;
+        color: #e5e7eb;
+      }
+
+      a {
+        color: #8b5cf6;
+        transition: all 0.2s;
+        text-decoration: underline !important;
+      }
+
+      a:hover {
+        color: #a78bfa;
+      }
+    </style>
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        document.getElementById("server-url").textContent = SERVER_URL;
+
+        const config = {
+          mcpServers: {
+            meridian: {
+              url: SERVER_URL,
+            },
+          },
+        };
+        document.getElementById("config-json").textContent = JSON.stringify(
+          config,
+          null,
+          2
+        );
+
+        const preBlocks = document.querySelectorAll("pre");
+        preBlocks.forEach((pre) => {
+          const button = document.createElement("button");
+          button.className = "copy-button";
+          button.textContent = "Copy";
+          button.onclick = () => {
+            const code = pre.querySelector("code")?.textContent || "";
+            navigator.clipboard.writeText(code).then(() => {
+              button.textContent = "Copied!";
+              button.classList.add("copied");
+              setTimeout(() => {
+                button.textContent = "Copy";
+                button.classList.remove("copied");
+              }, 2000);
+            });
+          };
+          pre.appendChild(button);
+        });
+      });
+    </script>
+  </head>
+
+  <body class="font-sans leading-relaxed flex flex-col min-h-screen">
+    <main class="container mx-auto px-4 pb-12 flex-grow pt-8">
+      <div class="max-w-4xl mx-auto">
+        <p class="text-sm uppercase tracking-widest text-primary font-semibold mb-2">
+          Meridian · Corporate Travel &amp; Expense
+        </p>
+        <h1 class="text-4xl font-bold font-heading text-white mb-6">
+          ✈️ Meridian MCP Server
+        </h1>
+        <p class="text-lg text-gray-300 mb-4">
+          Meridian is a (fictional) B2B travel &amp; expense platform — think
+          Navan or Ramp — exposed as a
+          <a href="https://modelcontextprotocol.com/" class="hover:text-primary"
+            >Model Context Protocol (MCP)</a
+          >
+          server so an AI agent can book trips, file expenses, approve reports,
+          and pull spend analytics on a user's behalf.
+        </p>
+        <p class="text-lg text-gray-300 mb-8">
+          It's a reference for
+          <strong class="text-white">Descope's B2B MCP auth</strong>: every
+          request is authenticated by
+          <a href="https://www.descope.com/" class="hover:text-primary"
+            >Descope</a
+          >, scoped to the caller's
+          <strong class="text-white">organization</strong> (tenant), and each
+          tool is authorized against the caller's
+          <strong class="text-white">role</strong>. Built with
+          <a href="https://gofastmcp.com/" class="hover:text-primary"
+            >FastMCP 3</a
+          >.
+        </p>
+
+        <h2 class="text-2xl font-bold font-heading text-white mt-8 mb-4">
+          Secured by Descope — B2B CIAM built for MCP
+        </h2>
+        <p class="text-gray-300 mb-4">
+          Meridian doesn't build auth. Descope is the authorization server in
+          front of the MCP endpoint, and it brings the full B2B identity stack
+          that agent-facing servers need:
+        </p>
+        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4 mb-10">
+          <div class="card rounded-lg p-6">
+            <h3 class="text-lg font-semibold text-white mb-2">
+              🏢 Multi-tenant by design
+            </h3>
+            <p class="text-gray-300">
+              Tokens carry the caller's organization. Every tool reads and writes
+              only that tenant's data — Acme's agent never sees Globex's
+              expenses, even on the same server.
+            </p>
+          </div>
+          <div class="card rounded-lg p-6">
+            <h3 class="text-lg font-semibold text-white mb-2">
+              🔐 Role-based tool access
+            </h3>
+            <p class="text-gray-300">
+              Each tool declares the OAuth scope it needs, so callers only ever
+              see the tools their role allows — enforced at the transport layer
+              on every request.
+            </p>
+          </div>
+          <div class="card rounded-lg p-6">
+            <h3 class="text-lg font-semibold text-white mb-2">
+              🪪 Enterprise SSO &amp; group mapping
+            </h3>
+            <p class="text-gray-300">
+              Connect the customer's Okta, Entra ID, or any OIDC/SAML IdP. Descope
+              maps IdP <strong class="text-white">groups → roles, scopes, and
+              permissions</strong>, and tenant-level policies control tool access
+              per organization — no code changes to add a new customer.
+            </p>
+          </div>
+          <div class="card rounded-lg p-6">
+            <h3 class="text-lg font-semibold text-white mb-2">
+              ⚡ ID-JAG / Cross-App Access
+            </h3>
+            <p class="text-gray-300">
+              Clients like <strong class="text-white">Claude</strong> and
+              <strong class="text-white">VS Code</strong> sign in instantly using
+              an enterprise-issued assertion — <strong class="text-white">no
+              separate SSO login or consent screen</strong>. IT authorizes the app
+              once at the IdP; users get Meridian pre-connected.
+            </p>
+          </div>
+          <div class="card rounded-lg p-6">
+            <h3 class="text-lg font-semibold text-white mb-2">
+              🤝 CIMD &amp; Dynamic Client Registration
+            </h3>
+            <p class="text-gray-300">
+              MCP clients self-onboard via CIMD / DCR — no hand-provisioned client
+              secrets. Client Registration Flows let you
+              <strong class="text-white">tag, classify, and verify</strong> each
+              client before it's trusted.
+            </p>
+          </div>
+          <div class="card rounded-lg p-6">
+            <h3 class="text-lg font-semibold text-white mb-2">
+              🧩 Bring your own auth
+            </h3>
+            <p class="text-gray-300">
+              Already have an auth system? Plug it in as an external
+              provider — no rip-and-replace. Descope becomes the OAuth 2.1
+              authorization server for your MCP endpoint while your existing
+              identity source stays the source of truth.
+            </p>
+          </div>
+        </div>
+
+        <h2 class="text-2xl font-bold font-heading text-white mt-8 mb-4">
+          Quick Start
+        </h2>
+        <div class="card rounded-lg p-6 mb-6">
+          <h3 class="text-xl font-semibold text-white mb-3">Server URL</h3>
+          <pre><code class="px-2 py-1 rounded" id="server-url"></code></pre>
+        </div>
+
+        <div class="card rounded-lg p-6 mb-6">
+          <h3 class="text-xl font-semibold text-white mb-3">Configuration</h3>
+          <pre><code id="config-json"></code></pre>
+        </div>
+
+        <h2 class="text-2xl font-bold font-heading text-white mt-8 mb-4">
+          Roles &amp; Scopes
+        </h2>
+        <div class="card rounded-lg p-6 mb-6">
+          <p class="text-gray-300 mb-4">
+            Roles are bundles of scopes. Connect with a token whose scopes match
+            a role, and only that role's tools appear.
+          </p>
+          <div class="overflow-x-auto">
+            <table class="w-full text-left text-gray-300">
+              <thead>
+                <tr class="border-b border-gray-700 text-white">
+                  <th class="py-2 pr-4 font-semibold">Role</th>
+                  <th class="py-2 font-semibold">Scopes</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-800">
+                <tr>
+                  <td class="py-3 pr-4"><span class="role-chip">Employee</span></td>
+                  <td class="py-3">
+                    <span class="scope-badge">expenses:read</span>
+                    <span class="scope-badge">expenses:write</span>
+                    <span class="scope-badge">trips:read</span>
+                    <span class="scope-badge">trips:book</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="py-3 pr-4"><span class="role-chip">Manager</span></td>
+                  <td class="py-3">
+                    <span class="text-gray-500">Employee +</span>
+                    <span class="scope-badge">expenses:approve</span>
+                    <span class="scope-badge">reports:read</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="py-3 pr-4">
+                    <span class="role-chip">Finance Admin</span>
+                  </td>
+                  <td class="py-3">
+                    <span class="text-gray-500">Manager +</span>
+                    <span class="scope-badge">admin</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <h2 class="text-2xl font-bold font-heading text-white mt-8 mb-4">
+          Tools &amp; Required Scopes
+        </h2>
+        <div class="card rounded-lg p-6 mb-6">
+          <p class="text-gray-300 mb-4">
+            Tools whose scope you don't hold are hidden from
+            <code class="px-1 rounded">tools/list</code> — clients only ever see
+            what their token allows.
+          </p>
+          <div class="overflow-x-auto">
+            <table class="w-full text-left text-gray-300">
+              <thead>
+                <tr class="border-b border-gray-700 text-white">
+                  <th class="py-2 pr-4 font-semibold">Tool</th>
+                  <th class="py-2 pr-4 font-semibold">Required scope</th>
+                  <th class="py-2 font-semibold">Description</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-800">
+                <tr>
+                  <td class="py-2 pr-4"><code>whoami</code></td>
+                  <td class="py-2 pr-4"><span class="text-gray-500">any authed</span></td>
+                  <td class="py-2">Identity, organization, and granted scopes</td>
+                </tr>
+                <tr>
+                  <td class="py-2 pr-4"><code>list_expenses</code></td>
+                  <td class="py-2 pr-4"><span class="scope-badge">expenses:read</span></td>
+                  <td class="py-2">List your org's expenses</td>
+                </tr>
+                <tr>
+                  <td class="py-2 pr-4"><code>get_expense</code></td>
+                  <td class="py-2 pr-4"><span class="scope-badge">expenses:read</span></td>
+                  <td class="py-2">Fetch one expense by id</td>
+                </tr>
+                <tr>
+                  <td class="py-2 pr-4"><code>submit_expense</code></td>
+                  <td class="py-2 pr-4"><span class="scope-badge">expenses:write</span></td>
+                  <td class="py-2">File a new expense report</td>
+                </tr>
+                <tr>
+                  <td class="py-2 pr-4"><code>approve_expense</code></td>
+                  <td class="py-2 pr-4"><span class="scope-badge">expenses:approve</span></td>
+                  <td class="py-2">Approve a pending expense (Manager)</td>
+                </tr>
+                <tr>
+                  <td class="py-2 pr-4"><code>reject_expense</code></td>
+                  <td class="py-2 pr-4"><span class="scope-badge">expenses:approve</span></td>
+                  <td class="py-2">Reject a pending expense (Manager)</td>
+                </tr>
+                <tr>
+                  <td class="py-2 pr-4"><code>search_flights</code></td>
+                  <td class="py-2 pr-4"><span class="scope-badge">trips:read</span></td>
+                  <td class="py-2">Search in-policy flights</td>
+                </tr>
+                <tr>
+                  <td class="py-2 pr-4"><code>list_trips</code></td>
+                  <td class="py-2 pr-4"><span class="scope-badge">trips:read</span></td>
+                  <td class="py-2">List booked trips</td>
+                </tr>
+                <tr>
+                  <td class="py-2 pr-4"><code>book_trip</code></td>
+                  <td class="py-2 pr-4"><span class="scope-badge">trips:book</span></td>
+                  <td class="py-2">Book a trip (enforced against policy)</td>
+                </tr>
+                <tr>
+                  <td class="py-2 pr-4"><code>expense_summary</code></td>
+                  <td class="py-2 pr-4"><span class="scope-badge">reports:read</span></td>
+                  <td class="py-2">Spend analytics &amp; budget usage (Manager)</td>
+                </tr>
+                <tr>
+                  <td class="py-2 pr-4"><code>list_employees</code></td>
+                  <td class="py-2 pr-4"><span class="scope-badge">admin</span></td>
+                  <td class="py-2">Organization directory (Finance Admin)</td>
+                </tr>
+                <tr>
+                  <td class="py-2 pr-4"><code>set_travel_policy</code></td>
+                  <td class="py-2 pr-4"><span class="scope-badge">admin</span></td>
+                  <td class="py-2">Update the org's travel/expense policy</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <h2 class="text-2xl font-bold font-heading text-white mt-8 mb-4">
+          API Endpoints
+        </h2>
+        <div class="card rounded-lg p-6 mb-6">
+          <div class="mb-4">
+            <h3 class="text-lg font-semibold text-white mb-2">MCP Server</h3>
+            <code class="bg-gray-800 px-2 py-1 rounded">POST /mcp</code>
+            <p class="mt-1 text-gray-300">
+              The main MCP endpoint (requires a Bearer token)
+            </p>
+          </div>
+          <div class="mb-4">
+            <h3 class="text-lg font-semibold text-white mb-2">OAuth Metadata</h3>
+            <code class="bg-gray-800 px-2 py-1 rounded"
+              >GET /.well-known/oauth-protected-resource/mcp</code
+            >
+            <p class="mt-1 text-gray-300">
+              Resource metadata for the MCP endpoint
+            </p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-white mb-2">
+              Authorization Server Metadata
+            </h3>
+            <code class="bg-gray-800 px-2 py-1 rounded"
+              >GET /.well-known/oauth-authorization-server</code
+            >
+            <p class="mt-1 text-gray-300">
+              OAuth 2.1 authorization server metadata (from Descope)
+            </p>
+          </div>
+        </div>
+
+        <h2 class="text-2xl font-bold font-heading text-white mt-8 mb-4">
+          Troubleshooting
+        </h2>
+        <div class="card rounded-lg p-6 mb-6">
+          <p class="mb-4 text-gray-300">
+            If you encounter authentication issues, try clearing the cached
+            authentication files:
+          </p>
+          <pre><code>rm -rf ~/.mcp-auth</code></pre>
+          <p class="mt-4 text-gray-300">
+            If a tool you expect is missing, confirm the scope is granted on your
+            token (decode your access token to inspect its scopes) and that the
+            scope is defined on your Descope MCP Server. If
+            <code class="px-1 rounded">whoami</code> shows the default org, your
+            token isn't carrying a tenant claim yet.
+          </p>
+        </div>
+      </div>
+    </main>
+    <footer class="bg-gray-900 py-6 mt-12">
+      <div class="container mx-auto px-4 text-center text-gray-400">
+        <p>
+          Meridian is a fictional company for demo purposes. Built with FastMCP 3
+          and Descope.
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/examples/b2b-mcp-server/pyproject.toml
+++ b/examples/b2b-mcp-server/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "meridian-b2b-mcp-server"
+version = "0.1.0"
+description = "Meridian — a fictional B2B travel & expense MCP server secured by Descope (multi-tenant + role-based scopes)"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "fastmcp>=3.4.2",
+    "python-dotenv>=1.1.1",
+    "uvicorn>=0.34.0",
+    "starlette>=0.47.1",
+]

--- a/examples/b2b-mcp-server/requirements.txt
+++ b/examples/b2b-mcp-server/requirements.txt
@@ -1,0 +1,4 @@
+fastmcp>=3.4.2
+python-dotenv>=1.1.1
+uvicorn>=0.34.0
+starlette>=0.47.1

--- a/examples/b2b-mcp-server/server.py
+++ b/examples/b2b-mcp-server/server.py
@@ -1,0 +1,489 @@
+"""Meridian MCP Server — a fictional B2B corporate travel & expense platform.
+
+Meridian is a stand-in for a real B2B SaaS company (think Navan, Ramp, Brex, or
+Box): a multi-tenant product where every customer is an *organization*, every
+user belongs to a tenant, and what a user can do is governed by their role.
+This server exposes Meridian's capabilities as MCP tools and shows how Descope
+secures a B2B MCP server on two axes at once:
+
+  1. Multi-tenant isolation (authentication + tenant claim).
+     Every request to the MCP endpoint must carry a valid Descope-issued JWT.
+     The token identifies the caller's organization (tenant), and every tool
+     reads and writes only that tenant's data. Acme's agent can never see
+     Globex's expenses, even though both hit the same server.
+
+  2. Role-based authorization (tool-level OAuth scopes).
+     Each tool declares the scope(s) it needs via `@mcp.tool(auth=...)`. A caller
+     whose token lacks a scope won't even see the tool in `tools/list`, and a
+     direct call returns "not found". Roles map to scope bundles:
+
+        Employee       expenses:read expenses:write trips:read trips:book
+        Manager        + expenses:approve reports:read
+        Finance Admin  + admin  (org directory, budgets, travel policy)
+
+This is a self-contained, in-memory demo — swap the store for a real database
+and the tenant/role model stays identical. The scopes used here must be defined
+on your Descope MCP Server and requested by the client during the OAuth flow.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+from fastmcp import FastMCP
+from fastmcp.server.auth import require_scopes
+from fastmcp.server.auth.providers.descope import DescopeProvider
+from fastmcp.server.dependencies import get_access_token
+from starlette.requests import Request
+from starlette.responses import FileResponse
+
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# --- Descope configuration (from environment) ---------------------------------
+# The public URL where this server is reachable. Used as the OAuth "resource"
+# identifier and to build the discovery (.well-known) endpoints.
+SERVER_URL = os.getenv("SERVER_URL", "http://localhost:8000")
+# The .well-known URL of your Descope MCP Server. Copy it from the Descope
+# Console under Agentic Identity Hub -> MCP Servers.
+DESCOPE_CONFIG_URL = os.getenv("DESCOPE_CONFIG_URL")
+
+if not DESCOPE_CONFIG_URL:
+    raise ValueError(
+        "Set DESCOPE_CONFIG_URL to your Descope MCP Server's .well-known URL "
+        "so the server can discover Descope's endpoints and validate tokens."
+    )
+
+# The DescopeProvider discovers Descope's endpoints from the MCP Server's
+# .well-known URL and configures JWT validation plus the OAuth 2.1 discovery
+# routes — no project ID or client credentials needed.
+auth_provider = DescopeProvider(
+    config_url=DESCOPE_CONFIG_URL,  # Your MCP Server .well-known URL
+    base_url=SERVER_URL,  # Your server's public URL
+)
+
+mcp = FastMCP(name="Meridian Travel & Expense MCP Server", auth=auth_provider)
+
+
+# --- In-memory, tenant-partitioned data store ---------------------------------
+# Keyed by tenant id. Two demo organizations are seeded so you can prove tenant
+# isolation: authenticate as Acme and you only ever touch Acme's data. Swap this
+# for a real per-tenant datastore in production.
+DEFAULT_TENANT = "acme-robotics"
+
+_ORGS: dict[str, dict] = {
+    "acme-robotics": {
+        "name": "Acme Robotics",
+        "monthly_travel_budget_usd": 50_000,
+        "travel_policy": {
+            "max_flight_usd": 1_200,
+            "max_hotel_nightly_usd": 350,
+            "cabin": "economy",
+            "requires_approval_over_usd": 1_000,
+        },
+        "employees": {
+            "e-101": {"id": "e-101", "name": "Dana Okafor", "role": "Employee", "email": "dana@acme.example"},
+            "e-102": {"id": "e-102", "name": "Miguel Santos", "role": "Manager", "email": "miguel@acme.example"},
+            "e-103": {"id": "e-103", "name": "Priya Nair", "role": "Finance Admin", "email": "priya@acme.example"},
+        },
+        "expenses": {
+            1: {"id": 1, "employee_id": "e-101", "merchant": "United Airlines", "category": "Airfare",
+                "amount_usd": 640.00, "date": "2026-06-14", "status": "approved"},
+            2: {"id": 2, "employee_id": "e-101", "merchant": "Marriott SFO", "category": "Lodging",
+                "amount_usd": 1_180.00, "date": "2026-06-15", "status": "pending"},
+            3: {"id": 3, "employee_id": "e-102", "merchant": "Uber", "category": "Ground Transport",
+                "amount_usd": 74.50, "date": "2026-06-16", "status": "pending"},
+        },
+        "trips": {
+            "t-9001": {"id": "t-9001", "employee_id": "e-101", "origin": "SFO", "destination": "JFK",
+                       "depart": "2026-07-10", "return": "2026-07-14", "status": "booked", "total_usd": 820.00},
+        },
+    },
+    "globex": {
+        "name": "Globex Corporation",
+        "monthly_travel_budget_usd": 20_000,
+        "travel_policy": {
+            "max_flight_usd": 800,
+            "max_hotel_nightly_usd": 250,
+            "cabin": "economy",
+            "requires_approval_over_usd": 500,
+        },
+        "employees": {
+            "g-201": {"id": "g-201", "name": "Lena Fischer", "role": "Employee", "email": "lena@globex.example"},
+            "g-202": {"id": "g-202", "name": "Tom Reyes", "role": "Finance Admin", "email": "tom@globex.example"},
+        },
+        "expenses": {
+            1: {"id": 1, "employee_id": "g-201", "merchant": "Delta", "category": "Airfare",
+                "amount_usd": 410.00, "date": "2026-06-20", "status": "approved"},
+        },
+        "trips": {},
+    },
+}
+
+# Per-tenant counters for newly created records.
+_NEXT_EXPENSE_ID: dict[str, int] = {"acme-robotics": 4, "globex": 2}
+_NEXT_TRIP_SEQ: dict[str, int] = {"acme-robotics": 9002, "globex": 3001}
+
+
+# --- Identity & tenant helpers ------------------------------------------------
+def _claims() -> dict:
+    """Return the validated claims from the caller's Descope access token."""
+    token = get_access_token()
+    return getattr(token, "claims", {}) or {}
+
+
+def _current_tenant() -> str:
+    """Resolve the caller's tenant (organization) from their token.
+
+    Descope multi-tenant tokens carry a `tenants` claim mapping tenant id ->
+    roles/permissions, and often a `dct` ("default/selected tenant") claim. We
+    honor those, then fall back to a custom `tenant` claim, then to the demo
+    default so the example still runs with a single-tenant project.
+    """
+    claims = _claims()
+
+    selected = claims.get("dct")
+    if isinstance(selected, str) and selected in _ORGS:
+        return selected
+
+    tenants = claims.get("tenants")
+    if isinstance(tenants, dict) and tenants:
+        for tid in tenants:
+            if tid in _ORGS:
+                return tid
+        # Token names a tenant we don't have seeded — surface it anyway.
+        return next(iter(tenants))
+
+    tenant = claims.get("tenant")
+    if isinstance(tenant, str) and tenant:
+        return tenant
+
+    return DEFAULT_TENANT
+
+
+def _org() -> dict:
+    """The current caller's organization record (auto-created if unseeded)."""
+    tid = _current_tenant()
+    return _ORGS.setdefault(
+        tid,
+        {
+            "name": tid,
+            "monthly_travel_budget_usd": 0,
+            "travel_policy": {},
+            "employees": {},
+            "expenses": {},
+            "trips": {},
+        },
+    )
+
+
+def _fmt_expense(e: dict, org: dict) -> str:
+    who = org["employees"].get(e["employee_id"], {}).get("name", e["employee_id"])
+    return (
+        f"[{e['id']}] {e['date']}  ${e['amount_usd']:,.2f}  {e['category']:<18} "
+        f"{e['merchant']:<18} {who:<16} — {e['status']}"
+    )
+
+
+# --- Tools: Expenses ----------------------------------------------------------
+# The DescopeProvider authenticates every request before these run; the tenant
+# helper scopes the data; `require_scopes` authorizes the action.
+
+
+@mcp.tool(auth=require_scopes("expenses:read"))
+async def list_expenses(status: str | None = None) -> str:
+    """List expense reports for your organization. Requires `expenses:read`.
+
+    Args:
+        status: Optional filter — one of `pending`, `approved`, `rejected`.
+    """
+    org = _org()
+    rows = sorted(org["expenses"].values(), key=lambda e: e["id"])
+    if status:
+        rows = [e for e in rows if e["status"] == status.lower()]
+    if not rows:
+        return f"No expenses for {org['name']}" + (f" with status '{status}'." if status else ".")
+    header = f"Expenses for {org['name']}:"
+    return header + "\n" + "\n".join(_fmt_expense(e, org) for e in rows)
+
+
+@mcp.tool(auth=require_scopes("expenses:read"))
+async def get_expense(expense_id: int) -> str:
+    """Fetch a single expense by id. Requires `expenses:read`.
+
+    Args:
+        expense_id: The id of the expense within your organization.
+    """
+    org = _org()
+    e = org["expenses"].get(expense_id)
+    if e is None:
+        return f"Expense {expense_id} not found in {org['name']}."
+    return _fmt_expense(e, org)
+
+
+@mcp.tool(auth=require_scopes("expenses:write"))
+async def submit_expense(merchant: str, category: str, amount_usd: float, date: str | None = None) -> str:
+    """Submit a new expense report. Requires `expenses:write`.
+
+    Anything over the org's approval threshold is created as `pending`; smaller
+    items are auto-approved — mirroring a real T&E policy engine.
+
+    Args:
+        merchant: Where the money was spent (e.g. "Delta", "Hilton").
+        category: Expense category (e.g. Airfare, Lodging, Meals).
+        amount_usd: Amount in US dollars.
+        date: ISO date (YYYY-MM-DD); defaults to today.
+    """
+    org = _org()
+    tid = _current_tenant()
+    threshold = org.get("travel_policy", {}).get("requires_approval_over_usd", 0)
+    new_id = _NEXT_EXPENSE_ID.get(tid, 1)
+    _NEXT_EXPENSE_ID[tid] = new_id + 1
+    expense = {
+        "id": new_id,
+        "employee_id": (_claims().get("sub") or "self"),
+        "merchant": merchant,
+        "category": category,
+        "amount_usd": round(float(amount_usd), 2),
+        "date": date or datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "status": "pending" if amount_usd > threshold else "approved",
+    }
+    org["expenses"][new_id] = expense
+    note = "" if expense["status"] == "approved" else f" (over ${threshold:,.0f} — needs manager approval)"
+    return f"Submitted expense:\n{_fmt_expense(expense, org)}{note}"
+
+
+@mcp.tool(auth=require_scopes("expenses:approve"))
+async def approve_expense(expense_id: int) -> str:
+    """Approve a pending expense. Requires `expenses:approve` (Manager).
+
+    Args:
+        expense_id: The id of the pending expense.
+    """
+    org = _org()
+    e = org["expenses"].get(expense_id)
+    if e is None:
+        return f"Expense {expense_id} not found in {org['name']}."
+    if e["status"] == "approved":
+        return f"Expense {expense_id} is already approved."
+    e["status"] = "approved"
+    return f"Approved expense:\n{_fmt_expense(e, org)}"
+
+
+@mcp.tool(auth=require_scopes("expenses:approve"))
+async def reject_expense(expense_id: int, reason: str) -> str:
+    """Reject a pending expense with a reason. Requires `expenses:approve`.
+
+    Args:
+        expense_id: The id of the pending expense.
+        reason: Why the expense is being rejected.
+    """
+    org = _org()
+    e = org["expenses"].get(expense_id)
+    if e is None:
+        return f"Expense {expense_id} not found in {org['name']}."
+    e["status"] = "rejected"
+    return f"Rejected expense {expense_id}: {reason}\n{_fmt_expense(e, org)}"
+
+
+# --- Tools: Travel ------------------------------------------------------------
+
+
+@mcp.tool(auth=require_scopes("trips:read"))
+async def search_flights(origin: str, destination: str, depart: str) -> str:
+    """Search bookable flights that fit your org's travel policy.
+
+    Requires `trips:read`. Results are filtered to the org's per-flight price
+    cap and cabin class, so the agent only ever offers in-policy options.
+
+    Args:
+        origin: Origin airport code (e.g. SFO).
+        destination: Destination airport code (e.g. JFK).
+        depart: Departure date (YYYY-MM-DD).
+    """
+    org = _org()
+    policy = org.get("travel_policy", {})
+    cap = policy.get("max_flight_usd", 10_000)
+    cabin = policy.get("cabin", "economy")
+    # Toy fare catalog; a real integration would call a GDS/booking API.
+    catalog = [
+        {"carrier": "United", "price_usd": 640, "stops": 0},
+        {"carrier": "Delta", "price_usd": 410, "stops": 1},
+        {"carrier": "JetBlue", "price_usd": 980, "stops": 0},
+        {"carrier": "Emirates", "price_usd": 3_200, "stops": 0},
+    ]
+    in_policy = [f for f in catalog if f["price_usd"] <= cap]
+    lines = [
+        f"{f['carrier']:<10} {origin}->{destination} {depart}  "
+        f"${f['price_usd']:,} {cabin}  {'nonstop' if f['stops'] == 0 else str(f['stops']) + ' stop(s)'}"
+        for f in in_policy
+    ]
+    hidden = len(catalog) - len(in_policy)
+    footer = f"\n({hidden} option(s) hidden — above {org['name']}'s ${cap:,} in-policy cap.)" if hidden else ""
+    return f"In-policy flights for {org['name']}:\n" + "\n".join(lines) + footer
+
+
+@mcp.tool(auth=require_scopes("trips:read"))
+async def list_trips() -> str:
+    """List booked trips for your organization. Requires `trips:read`."""
+    org = _org()
+    if not org["trips"]:
+        return f"No trips booked for {org['name']}."
+    lines = []
+    for t in org["trips"].values():
+        who = org["employees"].get(t["employee_id"], {}).get("name", t["employee_id"])
+        lines.append(
+            f"[{t['id']}] {t['origin']}->{t['destination']}  {t['depart']} to {t['return']}  "
+            f"${t['total_usd']:,.2f}  {who} — {t['status']}"
+        )
+    return f"Trips for {org['name']}:\n" + "\n".join(lines)
+
+
+@mcp.tool(auth=require_scopes("trips:book"))
+async def book_trip(origin: str, destination: str, depart: str, ret: str, total_usd: float) -> str:
+    """Book a trip for the caller. Requires `trips:book`.
+
+    Args:
+        origin: Origin airport code.
+        destination: Destination airport code.
+        depart: Departure date (YYYY-MM-DD).
+        ret: Return date (YYYY-MM-DD).
+        total_usd: Total trip cost in US dollars.
+    """
+    org = _org()
+    tid = _current_tenant()
+    cap = org.get("travel_policy", {}).get("max_flight_usd", 10_000)
+    if total_usd > cap * 2:  # round-trip sanity check against policy
+        return (
+            f"Cannot book: ${total_usd:,.2f} exceeds {org['name']}'s travel policy. "
+            f"Per-flight cap is ${cap:,}."
+        )
+    seq = _NEXT_TRIP_SEQ.get(tid, 1)
+    _NEXT_TRIP_SEQ[tid] = seq + 1
+    trip_id = f"t-{seq}"
+    trip = {
+        "id": trip_id,
+        "employee_id": (_claims().get("sub") or "self"),
+        "origin": origin,
+        "destination": destination,
+        "depart": depart,
+        "return": ret,
+        "status": "booked",
+        "total_usd": round(float(total_usd), 2),
+    }
+    org["trips"][trip_id] = trip
+    return f"Booked trip {trip_id}: {origin}->{destination} {depart} to {ret} for ${total_usd:,.2f}."
+
+
+# --- Tools: Reporting (Manager) ----------------------------------------------
+
+
+@mcp.tool(auth=require_scopes("reports:read"))
+async def expense_summary() -> str:
+    """Spend analytics for your organization. Requires `reports:read` (Manager).
+
+    Summarizes total and per-category spend and shows budget utilization.
+    """
+    org = _org()
+    expenses = list(org["expenses"].values())
+    total = sum(e["amount_usd"] for e in expenses)
+    by_cat: dict[str, float] = {}
+    for e in expenses:
+        by_cat[e["category"]] = by_cat.get(e["category"], 0.0) + e["amount_usd"]
+    budget = org.get("monthly_travel_budget_usd", 0)
+    pending = sum(1 for e in expenses if e["status"] == "pending")
+    lines = [f"Spend summary — {org['name']}"]
+    lines.append(f"  Total logged:   ${total:,.2f}")
+    if budget:
+        lines.append(f"  Monthly budget: ${budget:,.2f}  ({total / budget:.0%} used)")
+    lines.append(f"  Pending approvals: {pending}")
+    lines.append("  By category:")
+    for cat, amt in sorted(by_cat.items(), key=lambda kv: -kv[1]):
+        lines.append(f"    {cat:<18} ${amt:,.2f}")
+    return "\n".join(lines)
+
+
+# --- Tools: Administration (Finance Admin) -----------------------------------
+
+
+@mcp.tool(auth=require_scopes("admin"))
+async def list_employees() -> str:
+    """List everyone in your organization. Requires `admin` (Finance Admin)."""
+    org = _org()
+    lines = [f"Employees — {org['name']}:"]
+    for emp in org["employees"].values():
+        lines.append(f"  {emp['id']}  {emp['name']:<16} {emp['role']:<14} {emp['email']}")
+    return "\n".join(lines)
+
+
+@mcp.tool(auth=require_scopes("admin"))
+async def set_travel_policy(
+    max_flight_usd: float | None = None,
+    max_hotel_nightly_usd: float | None = None,
+    requires_approval_over_usd: float | None = None,
+) -> str:
+    """Update your organization's travel policy. Requires `admin`.
+
+    Only the fields you pass are changed. These caps immediately govern
+    `search_flights`, `book_trip`, and `submit_expense`.
+
+    Args:
+        max_flight_usd: New per-flight price cap.
+        max_hotel_nightly_usd: New nightly hotel cap.
+        requires_approval_over_usd: New auto-approval threshold for expenses.
+    """
+    org = _org()
+    policy = org.setdefault("travel_policy", {})
+    if max_flight_usd is not None:
+        policy["max_flight_usd"] = round(float(max_flight_usd), 2)
+    if max_hotel_nightly_usd is not None:
+        policy["max_hotel_nightly_usd"] = round(float(max_hotel_nightly_usd), 2)
+    if requires_approval_over_usd is not None:
+        policy["requires_approval_over_usd"] = round(float(requires_approval_over_usd), 2)
+    return f"Updated travel policy for {org['name']}: {policy}"
+
+
+# --- Tool: Identity (any authenticated caller) --------------------------------
+
+
+@mcp.tool
+async def whoami() -> str:
+    """Show the caller's identity, organization, and granted scopes.
+
+    Requires only a valid token (no specific scope). Handy for demos: it makes
+    the B2B model visible — which organization the token belongs to and exactly
+    what the caller is authorized to do.
+    """
+    token = get_access_token()
+    claims = _claims()
+    tid = _current_tenant()
+    org = _ORGS.get(tid, {})
+    scopes = getattr(token, "scopes", None) or []
+    lines = [
+        "You are authenticated with Descope.",
+        f"  Subject:      {claims.get('sub', 'unknown')}",
+        f"  Organization: {org.get('name', tid)}  (tenant: {tid})",
+        f"  Scopes:       {', '.join(scopes) if scopes else '(none)'}",
+    ]
+    return "\n".join(lines)
+
+
+# --- Landing page -------------------------------------------------------------
+@mcp.custom_route("/", methods=["GET"])
+async def serve_index(request: Request) -> FileResponse:
+    return FileResponse(os.path.join(os.path.dirname(__file__), "index.html"))
+
+
+# The Streamable HTTP app exposes the MCP endpoint plus the OAuth discovery
+# routes (`/.well-known/oauth-authorization-server`, `oauth-protected-resource`).
+app = mcp.http_app(path="/mcp")
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
## What

Replaces the placeholder under `examples/b2b-mcp-server` (which was a copy of the weather server) with a purpose-built **B2B** example: **Meridian**, a fictional corporate **travel & expense** platform — a stand-in for a real B2B SaaS company (Navan / Ramp / Box) — exposed as a **FastMCP 3** MCP server secured by **Descope**.

Built for demos of Descope's B2B capabilities with MCP auth.

## Why it's a good B2B representation

It demonstrates the two axes that define B2B identity:

1. **Multi-tenant isolation** — every request's Descope JWT identifies the caller's *organization*; each tool resolves the tenant from the token (`dct` / `tenants` claims) and reads/writes only that tenant's data. Two demo orgs (Acme Robotics, Globex) are seeded so isolation is provable.
2. **Role-based authorization** — each tool declares `require_scopes(...)`; roles map to scope bundles (Employee / Manager / Finance Admin), so the same server presents a different toolset per role.

**12 tools** across expenses, travel, reporting, and admin, plus `whoami` for a clean demo opener. Travel-policy caps are enforced live across `search_flights` / `book_trip` / `submit_expense`.

## Descope B2B CIAM value, documented

The README and rebranded landing page highlight the full value Descope brings as a B2B CIAM provider for MCP servers:

- **ID-JAG / Cross-App Access** (Enterprise-Managed Authorization, MCP 2025-11-25) — enabled per **tenant**; lets workforce clients like **Claude** and **VS Code** exchange an IdP-issued assertion for an access token with no separate SSO login or consent. Full RFC 8693 → RFC 7523 flow documented.
- **CIMD / Dynamic Client Registration** + client registration flows
- **Enterprise SSO** with group → roles/scopes/permissions mapping and tenant-level tool-access policies
- **Bring-your-own / external authentication** with Descope as the MCP server's authorization server

## Verified

- FastMCP 3.4.3; all imports resolve, all 12 tools register
- Scope-gating confirmed (unauthenticated `tools/list` shows only `whoami`)
- Live boot: landing page `200`, `POST /mcp` → `401` unauthenticated, OAuth discovery metadata `200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)